### PR TITLE
feat(phase8): implement Report Agent with citation validation

### DIFF
--- a/src/agents/report_agent.py
+++ b/src/agents/report_agent.py
@@ -1,0 +1,136 @@
+"""Report agent for generating structured research reports."""
+
+from collections.abc import AsyncIterable
+from typing import TYPE_CHECKING, Any
+
+from agent_framework import (
+    AgentRunResponse,
+    AgentRunResponseUpdate,
+    AgentThread,
+    BaseAgent,
+    ChatMessage,
+    Role,
+)
+from pydantic_ai import Agent
+
+from src.agent_factory.judges import get_model
+from src.prompts.report import SYSTEM_PROMPT, format_report_prompt
+from src.utils.citation_validator import validate_references
+from src.utils.models import Evidence, ResearchReport
+
+if TYPE_CHECKING:
+    from src.services.embeddings import EmbeddingService
+
+
+class ReportAgent(BaseAgent):  # type: ignore[misc]
+    """Generates structured scientific reports from evidence and hypotheses."""
+
+    def __init__(
+        self,
+        evidence_store: dict[str, Any],
+        embedding_service: "EmbeddingService | None" = None,  # For diverse selection
+    ) -> None:
+        super().__init__(
+            name="ReportAgent",
+            description="Generates structured scientific research reports with citations",
+        )
+        self._evidence_store = evidence_store
+        self._embeddings = embedding_service
+        self._agent: Agent[None, ResearchReport] | None = None  # Lazy init
+
+    def _get_agent(self) -> Agent[None, ResearchReport]:
+        """Lazy initialization of LLM agent to avoid requiring API keys at import."""
+        if self._agent is None:
+            self._agent = Agent(
+                model=get_model(),
+                output_type=ResearchReport,
+                system_prompt=SYSTEM_PROMPT,
+            )
+        return self._agent
+
+    async def run(
+        self,
+        messages: str | ChatMessage | list[str] | list[ChatMessage] | None = None,
+        *,
+        thread: AgentThread | None = None,
+        **kwargs: Any,
+    ) -> AgentRunResponse:
+        """Generate research report."""
+        query = self._extract_query(messages)
+
+        # Gather all context
+        evidence: list[Evidence] = self._evidence_store.get("current", [])
+        hypotheses = self._evidence_store.get("hypotheses", [])
+        assessment = self._evidence_store.get("last_assessment", {})
+
+        if not evidence:
+            return AgentRunResponse(
+                messages=[
+                    ChatMessage(
+                        role=Role.ASSISTANT,
+                        text="Cannot generate report: No evidence collected.",
+                    )
+                ],
+                response_id="report-no-evidence",
+            )
+
+        # Build metadata
+        metadata = {
+            "sources": list(set(e.citation.source for e in evidence)),
+            "iterations": self._evidence_store.get("iteration_count", 0),
+        }
+
+        # Generate report (format_report_prompt is now async)
+        prompt = await format_report_prompt(
+            query=query,
+            evidence=evidence,
+            hypotheses=hypotheses,
+            assessment=assessment,
+            metadata=metadata,
+            embeddings=self._embeddings,
+        )
+
+        result = await self._get_agent().run(prompt)
+        report = result.output
+
+        # ═══════════════════════════════════════════════════════════════════
+        # 🚨 CRITICAL: Validate citations to prevent hallucination
+        # ═══════════════════════════════════════════════════════════════════
+        report = validate_references(report, evidence)
+
+        # Store validated report
+        self._evidence_store["final_report"] = report
+
+        # Return markdown version
+        return AgentRunResponse(
+            messages=[ChatMessage(role=Role.ASSISTANT, text=report.to_markdown())],
+            response_id="report-complete",
+            additional_properties={"report": report.model_dump()},
+        )
+
+    def _extract_query(
+        self, messages: str | ChatMessage | list[str] | list[ChatMessage] | None
+    ) -> str:
+        """Extract query from messages."""
+        if isinstance(messages, str):
+            return messages
+        elif isinstance(messages, ChatMessage):
+            return messages.text or ""
+        elif isinstance(messages, list):
+            for msg in reversed(messages):
+                if isinstance(msg, ChatMessage) and msg.role == Role.USER:
+                    return msg.text or ""
+                elif isinstance(msg, str):
+                    return msg
+        return ""
+
+    async def run_stream(
+        self,
+        messages: str | ChatMessage | list[str] | list[ChatMessage] | None = None,
+        *,
+        thread: AgentThread | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterable[AgentRunResponseUpdate]:
+        """Streaming wrapper."""
+        result = await self.run(messages, thread=thread, **kwargs)
+        yield AgentRunResponseUpdate(messages=result.messages, response_id=result.response_id)

--- a/src/utils/citation_validator.py
+++ b/src/utils/citation_validator.py
@@ -1,0 +1,75 @@
+"""Citation validation to prevent LLM hallucination.
+
+CRITICAL: Medical research requires accurate citations.
+This module validates that all references exist in collected evidence.
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.utils.models import Evidence, ResearchReport
+
+logger = logging.getLogger(__name__)
+
+
+def validate_references(report: "ResearchReport", evidence: list["Evidence"]) -> "ResearchReport":
+    """Ensure all references actually exist in collected evidence.
+
+    CRITICAL: Prevents LLM hallucination of citations.
+
+    Args:
+        report: The generated research report
+        evidence: All evidence collected during research
+
+    Returns:
+        Report with only valid references (hallucinated ones removed)
+    """
+    # Build set of valid URLs from evidence
+    valid_urls = {e.citation.url for e in evidence}
+    # Also check titles (case-insensitive) as fallback
+    valid_titles = {e.citation.title.lower() for e in evidence}
+
+    validated_refs = []
+    removed_count = 0
+
+    for ref in report.references:
+        ref_url = ref.get("url", "")
+        ref_title = ref.get("title", "").lower()
+
+        # Check if URL matches collected evidence
+        if ref_url in valid_urls:
+            validated_refs.append(ref)
+        # Fallback: check title match (URLs might differ slightly)
+        elif ref_title and any(ref_title in t or t in ref_title for t in valid_titles):
+            validated_refs.append(ref)
+        else:
+            removed_count += 1
+            logger.warning(
+                f"Removed hallucinated reference: '{ref.get('title', 'Unknown')}' "
+                f"(URL: {ref_url[:50]}...)"
+            )
+
+    if removed_count > 0:
+        logger.info(
+            f"Citation validation removed {removed_count} hallucinated references. "
+            f"{len(validated_refs)} valid references remain."
+        )
+
+    # Update report with validated references
+    report.references = validated_refs
+    return report
+
+
+def build_reference_from_evidence(evidence: "Evidence") -> dict[str, str]:
+    """Build a properly formatted reference from evidence.
+
+    Use this to ensure references match the original evidence exactly.
+    """
+    return {
+        "title": evidence.citation.title,
+        "authors": ", ".join(evidence.citation.authors or ["Unknown"]),
+        "source": evidence.citation.source,
+        "date": evidence.citation.date or "n.d.",
+        "url": evidence.citation.url,
+    }

--- a/tests/unit/agents/test_report_agent.py
+++ b/tests/unit/agents/test_report_agent.py
@@ -1,0 +1,228 @@
+"""Unit tests for ReportAgent."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agents.report_agent import ReportAgent
+from src.utils.models import (
+    Citation,
+    Evidence,
+    MechanismHypothesis,
+    ReportSection,
+    ResearchReport,
+)
+
+
+@pytest.fixture
+def sample_evidence() -> list[Evidence]:
+    return [
+        Evidence(
+            content="Metformin activates AMPK...",
+            citation=Citation(
+                source="pubmed",
+                title="Metformin mechanisms",
+                url="https://pubmed.ncbi.nlm.nih.gov/12345/",
+                date="2023",
+                authors=["Smith J", "Jones A"],
+            ),
+        )
+    ]
+
+
+@pytest.fixture
+def sample_hypotheses() -> list[MechanismHypothesis]:
+    return [
+        MechanismHypothesis(
+            drug="Metformin",
+            target="AMPK",
+            pathway="mTOR inhibition",
+            effect="Neuroprotection",
+            confidence=0.8,
+            search_suggestions=[],
+        )
+    ]
+
+
+@pytest.fixture
+def mock_report() -> ResearchReport:
+    return ResearchReport(
+        title="Drug Repurposing Analysis: Metformin for Alzheimer's",
+        executive_summary=(
+            "This report analyzes metformin as a potential candidate for "
+            "repurposing in Alzheimer's disease treatment. It summarizes "
+            "findings from mechanistic studies showing AMPK activation effects "
+            "and reviews clinical data. The evidence suggests a potential "
+            "neuroprotective role, although clinical trials are still limited."
+        ),
+        research_question="Can metformin be repurposed for Alzheimer's disease?",
+        methodology=ReportSection(
+            title="Methodology", content="Searched PubMed and web sources..."
+        ),
+        hypotheses_tested=[
+            {"mechanism": "Metformin -> AMPK -> neuroprotection", "supported": 5, "contradicted": 1}
+        ],
+        mechanistic_findings=ReportSection(
+            title="Mechanistic Findings", content="Evidence suggests AMPK activation..."
+        ),
+        clinical_findings=ReportSection(
+            title="Clinical Findings", content="Limited clinical data available..."
+        ),
+        drug_candidates=["Metformin"],
+        limitations=["Abstract-level analysis only"],
+        conclusion="Metformin shows promise...",
+        references=[],
+        sources_searched=["pubmed", "web"],
+        total_papers_reviewed=10,
+        search_iterations=3,
+        confidence_score=0.75,
+    )
+
+
+@pytest.mark.asyncio
+async def test_report_agent_generates_report(
+    sample_evidence: list[Evidence],
+    sample_hypotheses: list[MechanismHypothesis],
+    mock_report: ResearchReport,
+) -> None:
+    """ReportAgent should generate structured report."""
+    store: dict[str, Any] = {
+        "current": sample_evidence,
+        "hypotheses": sample_hypotheses,
+        "last_assessment": {"mechanism_score": 8, "clinical_score": 6},
+    }
+
+    with (
+        patch("src.agents.report_agent.get_model") as mock_get_model,
+        patch("src.agents.report_agent.Agent") as mock_agent_class,
+    ):
+        mock_get_model.return_value = MagicMock()
+        mock_result = MagicMock()
+        mock_result.output = mock_report
+        mock_agent_class.return_value.run = AsyncMock(return_value=mock_result)
+
+        agent = ReportAgent(store)
+        response = await agent.run("metformin alzheimer")
+
+        assert response.messages[0].text is not None
+        assert "Executive Summary" in response.messages[0].text
+        assert "Methodology" in response.messages[0].text
+        assert "References" in response.messages[0].text
+
+
+@pytest.mark.asyncio
+async def test_report_agent_no_evidence() -> None:
+    """ReportAgent should handle empty evidence gracefully."""
+    store: dict[str, Any] = {"current": [], "hypotheses": []}
+
+    # Lazy init means no patching needed - agent only instantiated when run() has evidence
+    agent = ReportAgent(store)
+    response = await agent.run("test query")
+
+    assert response.messages[0].text is not None
+    assert "Cannot generate report" in response.messages[0].text
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 🚨 CRITICAL: Citation Validation Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_report_agent_removes_hallucinated_citations(
+    sample_evidence: list[Evidence],
+) -> None:
+    """ReportAgent should remove citations not in evidence."""
+    from src.utils.citation_validator import validate_references
+
+    # Create report with mix of valid and hallucinated references
+    report_with_hallucinations = ResearchReport(
+        title="Test Report",
+        executive_summary=(
+            "This is a test report for citation validation. It needs to be "
+            "sufficiently long to pass validation. We are ensuring that the "
+            "system correctly identifies and removes citations that do not "
+            "appear in collected evidence. This prevents hallucinations."
+        ),
+        research_question="Testing citation validation",
+        methodology=ReportSection(title="Methodology", content="Test"),
+        hypotheses_tested=[],
+        mechanistic_findings=ReportSection(title="Mechanistic", content="Test"),
+        clinical_findings=ReportSection(title="Clinical", content="Test"),
+        drug_candidates=["TestDrug"],
+        limitations=["Test limitation"],
+        conclusion="Test conclusion",
+        references=[
+            # Valid reference (matches sample_evidence)
+            {
+                "title": "Metformin mechanisms",
+                "url": "https://pubmed.ncbi.nlm.nih.gov/12345/",
+                "authors": "Smith J, Jones A",
+                "date": "2023",
+                "source": "pubmed",
+            },
+            # HALLUCINATED reference (URL doesn't exist in evidence)
+            {
+                "title": "Fake Paper That Doesn't Exist",
+                "url": "https://fake-journal.com/made-up-paper",
+                "authors": "Hallucinated A",
+                "date": "2024",
+                "source": "fake",
+            },
+            # Another HALLUCINATED reference
+            {
+                "title": "Invented Research",
+                "url": "https://pubmed.ncbi.nlm.nih.gov/99999999/",
+                "authors": "NotReal B",
+                "date": "2025",
+                "source": "pubmed",
+            },
+        ],
+        sources_searched=["pubmed"],
+        total_papers_reviewed=1,
+        search_iterations=1,
+        confidence_score=0.5,
+    )
+
+    # Validate - should remove hallucinated references
+    validated_report = validate_references(report_with_hallucinations, sample_evidence)
+
+    # Only the valid reference should remain
+    assert len(validated_report.references) == 1
+    assert validated_report.references[0]["title"] == "Metformin mechanisms"
+    # Check that "Fake Paper" is NOT in the string representation of the references list
+    # (This is a bit safer than checking presence in list of dicts if structure varies)
+    ref_urls = [r.get("url") for r in validated_report.references]
+    assert "https://fake-journal.com/made-up-paper" not in ref_urls
+
+
+def test_citation_validator_handles_empty_references() -> None:
+    """Citation validator should handle reports with no references."""
+    from src.utils.citation_validator import validate_references
+
+    report = ResearchReport(
+        title="Empty Refs Report",
+        executive_summary=(
+            "This report has no references. It is designed to test the "
+            "validator's handling of empty reference lists. We must ensure "
+            "that the system does not crash when a report contains no "
+            "citations. This is a valid edge case in early-stage research."
+        ),
+        research_question="Testing empty refs",
+        methodology=ReportSection(title="Methodology", content="Test"),
+        hypotheses_tested=[],
+        mechanistic_findings=ReportSection(title="Mechanistic", content="Test"),
+        clinical_findings=ReportSection(title="Clinical", content="Test"),
+        drug_candidates=[],
+        limitations=[],
+        conclusion="Test",
+        references=[],  # Empty!
+        sources_searched=[],
+        total_papers_reviewed=0,
+        search_iterations=0,
+        confidence_score=0.0,
+    )
+
+    validated = validate_references(report, [])
+    assert validated.references == []


### PR DESCRIPTION
## Summary
- Implements ReportAgent for generating structured research reports with citations
- Adds citation_validator.py to prevent LLM hallucination of references
- Report prompts with strict citation requirements
- Integrates with MagenticOrchestrator for multi-agent workflow

## Key Features
- **ReportAgent**: Generates ResearchReport Pydantic model with markdown export
- **Citation Validation**: Removes hallucinated references not in collected evidence
- **Diverse Evidence Selection**: Uses MMR algorithm via embedding service
- **Lazy Initialization**: Same pattern as HypothesisAgent - no API keys at import

## Test Plan
- [x] Unit tests for report generation
- [x] Unit tests for citation validation (removes hallucinated refs)
- [x] Unit tests for empty references handling
- [x] All 57 tests pass
- [x] Ruff lint clean
- [x] Mypy type check clean

## Fixes Applied
- Lazy init via `_get_agent()` pattern (consistent with Phase 7)
- `output_type` instead of `result_type` (pydantic-ai API)
- `result.output` instead of `result.data`
- Line length fixes in tests
- Proper mocking of `get_model` in tests

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured scientific report generation as the final step in the research workflow.
  * Reports include executive summary, methodology, hypotheses tested, findings, and validated citations.
  * Implemented citation validation to prevent hallucinated references in generated reports.
  * Reports are formatted in Markdown for easy sharing and readability.

* **Tests**
  * Added comprehensive unit tests for report generation and citation validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->