### PR TITLE
fix: specify Python 3.11 for HuggingFace Spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ colorFrom: blue
 colorTo: purple
 sdk: gradio
 sdk_version: 5.0.0
+python_version: "3.11"
 app_file: src/app.py
 pinned: false
 license: mit


### PR DESCRIPTION
## Summary

HuggingFace Spaces was defaulting to Python 3.10, causing build failures due to `datetime.UTC` (Python 3.11+ feature).

## Changes

- Add `python_version: "3.11"` to README.md frontmatter
- This tells HuggingFace Spaces to use Python 3.11 instead of defaulting to 3.10

## Why this approach

Our project is designed for Python 3.11+ (`requires-python = ">=3.11"` in pyproject.toml). Rather than downgrading the entire codebase to 3.10, we simply specify the correct Python version for HuggingFace Spaces deployment.

## Test plan

- [x] `make check` passes (99 tests, 68% coverage)
- [ ] HuggingFace Spaces build succeeds with Python 3.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated README metadata to specify Python version compatibility information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->