### PR TITLE
feat(clinicaltrials): SPEC_14 Outcome Measures

### DIFF
--- a/tests/unit/tools/test_clinicaltrials.py
+++ b/tests/unit/tools/test_clinicaltrials.py
@@ -128,6 +128,146 @@ class TestClinicalTrialsTool:
             assert results == []
 
 
+@pytest.mark.unit
+class TestClinicalTrialsOutcomes:
+    """Tests for outcome measure extraction."""
+
+    @pytest.fixture
+    def tool(self) -> ClinicalTrialsTool:
+        return ClinicalTrialsTool()
+
+    @pytest.mark.asyncio
+    async def test_extracts_primary_outcome(self, tool: ClinicalTrialsTool) -> None:
+        """Test that primary outcome is extracted from response."""
+        mock_study = {
+            "protocolSection": {
+                "identificationModule": {"nctId": "NCT12345678", "briefTitle": "Test"},
+                "statusModule": {"overallStatus": "COMPLETED", "startDateStruct": {"date": "2023"}},
+                "descriptionModule": {"briefSummary": "Summary"},
+                "designModule": {"phases": ["PHASE3"]},
+                "conditionsModule": {"conditions": ["ED"]},
+                "armsInterventionsModule": {"interventions": []},
+                "outcomesModule": {
+                    "primaryOutcomes": [
+                        {"measure": "Change in IIEF-EF score", "timeFrame": "Week 12"}
+                    ]
+                },
+            },
+            "hasResults": True,
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"studies": [mock_study]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=mock_response):
+            results = await tool.search("test", max_results=1)
+
+            assert len(results) == 1
+            assert "Primary Outcome" in results[0].content
+            assert "IIEF-EF" in results[0].content
+            assert "Week 12" in results[0].content
+
+    @pytest.mark.asyncio
+    async def test_includes_results_status(self, tool: ClinicalTrialsTool) -> None:
+        """Test that results availability is shown."""
+        mock_study = {
+            "protocolSection": {
+                "identificationModule": {"nctId": "NCT12345678", "briefTitle": "Test"},
+                "statusModule": {
+                    "overallStatus": "COMPLETED",
+                    "startDateStruct": {"date": "2023"},
+                    # Note: resultsFirstPostDateStruct, not resultsFirstSubmitDate
+                    "resultsFirstPostDateStruct": {"date": "2024-06-15"},
+                },
+                "descriptionModule": {"briefSummary": "Summary"},
+                "designModule": {"phases": ["PHASE3"]},
+                "conditionsModule": {"conditions": ["ED"]},
+                "armsInterventionsModule": {"interventions": []},
+                "outcomesModule": {},
+            },
+            "hasResults": True,  # Note: hasResults is TOP-LEVEL
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"studies": [mock_study]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=mock_response):
+            results = await tool.search("test", max_results=1)
+
+            assert "Results Available: Yes" in results[0].content
+            assert "2024-06-15" in results[0].content
+
+    @pytest.mark.asyncio
+    async def test_shows_no_results_when_missing(self, tool: ClinicalTrialsTool) -> None:
+        """Test that missing results are indicated."""
+        mock_study = {
+            "protocolSection": {
+                "statusModule": {
+                    "overallStatus": "RECRUITING",
+                    "startDateStruct": {"date": "2024"},
+                },
+                "descriptionModule": {"briefSummary": "Summary"},
+                "designModule": {"phases": ["PHASE2"]},
+                "conditionsModule": {"conditions": ["ED"]},
+                "armsInterventionsModule": {"interventions": []},
+                "outcomesModule": {},
+            },
+            "hasResults": False,
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"studies": [mock_study]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=mock_response):
+            results = await tool.search("test", max_results=1)
+
+            assert "Results Available: Not yet posted" in results[0].content
+
+    @pytest.mark.asyncio
+    async def test_boosts_relevance_for_results(self, tool: ClinicalTrialsTool) -> None:
+        """Trials with results should have higher relevance score."""
+        with_results = {
+            "protocolSection": {
+                "identificationModule": {"nctId": "NCT11111111", "briefTitle": "With Results"},
+                "statusModule": {"overallStatus": "COMPLETED", "startDateStruct": {"date": "2023"}},
+                "descriptionModule": {"briefSummary": "Summary"},
+                "designModule": {"phases": []},
+                "conditionsModule": {"conditions": []},
+                "armsInterventionsModule": {"interventions": []},
+                "outcomesModule": {},
+            },
+            "hasResults": True,
+        }
+        without_results = {
+            "protocolSection": {
+                "identificationModule": {"nctId": "NCT22222222", "briefTitle": "No Results"},
+                "statusModule": {
+                    "overallStatus": "RECRUITING",
+                    "startDateStruct": {"date": "2024"},
+                },
+                "descriptionModule": {"briefSummary": "Summary"},
+                "designModule": {"phases": []},
+                "conditionsModule": {"conditions": []},
+                "armsInterventionsModule": {"interventions": []},
+                "outcomesModule": {},
+            },
+            "hasResults": False,
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"studies": [with_results, without_results]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=mock_response):
+            results = await tool.search("test", max_results=2)
+
+            assert results[0].relevance == 0.90  # With results
+            assert results[1].relevance == 0.85  # Without results
+
+
 @pytest.mark.integration
 class TestClinicalTrialsIntegration:
     """Integration tests with real API."""
@@ -150,3 +290,17 @@ class TestClinicalTrialsIntegration:
             or "phase" in all_content
         )
         assert has_intervention
+
+    @pytest.mark.asyncio
+    async def test_real_completed_trial_has_outcome(self) -> None:
+        """Real completed Phase 3 trials should have outcome measures."""
+        tool = ClinicalTrialsTool()
+
+        # Search for completed Phase 3 ED trials (likely to have outcomes)
+        results = await tool.search(
+            "sildenafil erectile dysfunction Phase 3 COMPLETED", max_results=3
+        )
+
+        # At least one should have primary outcome
+        has_outcome = any("Primary Outcome" in r.content for r in results)
+        assert has_outcome, "No completed trials with outcome measures found"


### PR DESCRIPTION
## Summary

Adds outcome measure extraction to ClinicalTrials.gov search results per SPEC_14.

**Changes:**
- Add `OutcomesModule` and `HasResults` to FIELDS constant
- Extract primary outcomes with measure and timeFrame
- Show results availability status with posted date
- Boost relevance for trials with results (0.90 vs 0.85)

## Files Changed

| File | Change |
|------|--------|
| `src/tools/clinicaltrials.py` | Add outcome extraction logic (+51 lines) |
| `tests/unit/tools/test_clinicaltrials.py` | Add 4 unit tests + 1 integration test |

## Test Plan

- [x] `test_extracts_primary_outcome` - Primary outcome measure + timeframe extracted
- [x] `test_includes_results_status` - hasResults: True shows "Results Available: Yes (posted DATE)"
- [x] `test_shows_no_results_when_missing` - hasResults: False shows "Results Available: Not yet posted"
- [x] `test_boosts_relevance_for_results` - Relevance 0.90 with results, 0.85 without
- [x] `test_real_completed_trial_has_outcome` - Integration test with real API

## Related

- Closes #95
- Depends on PR #98 (SPEC_13)