### PR TITLE
feat: SPEC_15 Advanced Mode Performance Optimization

### DIFF
--- a/examples/benchmark_advanced.py
+++ b/examples/benchmark_advanced.py
@@ -1,7 +1,6 @@
 """Benchmark Advanced mode with different max_rounds settings."""
 
 import asyncio
-import os
 import time
 
 from src.orchestrators.advanced import AdvancedOrchestrator
@@ -9,9 +8,8 @@ from src.orchestrators.advanced import AdvancedOrchestrator
 
 async def benchmark(max_rounds: int) -> float:
     """Run benchmark with specified rounds, return elapsed time."""
-    os.environ["ADVANCED_MAX_ROUNDS"] = str(max_rounds)
-
-    orch = AdvancedOrchestrator()
+    # Pass max_rounds explicitly instead of mutating os.environ
+    orch = AdvancedOrchestrator(max_rounds=max_rounds)
     start = time.time()
 
     print(f"\nStarting benchmark with max_rounds={max_rounds}...")

--- a/src/agents/magentic_agents.py
+++ b/src/agents/magentic_agents.py
@@ -92,9 +92,10 @@ When asked to evaluate:
 ## CRITICAL OUTPUT FORMAT
 To ensure the workflow terminates when appropriate, you MUST follow these rules:
 
-IF evidence is SUFFICIENT (Confidence >= 70%):
-   Start your response EXACTLY with: "✅ SUFFICIENT EVIDENCE (confidence: <%>). STOP SEARCHING.
-   Delegate to ReportAgent NOW."
+IF evidence is SUFFICIENT (confidence >= 70%):
+   Start your response with a line like:
+   "✅ SUFFICIENT EVIDENCE (confidence: 72%). STOP SEARCHING. Delegate to ReportAgent NOW."
+   Use your actual numeric confidence instead of 72.
    Then explain why.
 
 IF evidence is INSUFFICIENT:

--- a/tests/unit/orchestrators/test_advanced_orchestrator.py
+++ b/tests/unit/orchestrators/test_advanced_orchestrator.py
@@ -12,29 +12,62 @@ class TestAdvancedOrchestratorConfig:
 
     def test_default_max_rounds_is_five(self) -> None:
         """Default max_rounds should be 5 for faster demos."""
-        with patch.dict(os.environ, {}, clear=True):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("src.orchestrators.advanced.check_magentic_requirements"),
+        ):
             # Clear any existing env var
             os.environ.pop("ADVANCED_MAX_ROUNDS", None)
-            orch = AdvancedOrchestrator.__new__(AdvancedOrchestrator)
-            orch.__init__()
+            orch = AdvancedOrchestrator()
             assert orch._max_rounds == 5
 
     def test_max_rounds_from_env(self) -> None:
         """max_rounds should be configurable via environment."""
-        with patch.dict(os.environ, {"ADVANCED_MAX_ROUNDS": "3"}):
-            orch = AdvancedOrchestrator.__new__(AdvancedOrchestrator)
-            orch.__init__()
+        with (
+            patch.dict(os.environ, {"ADVANCED_MAX_ROUNDS": "3"}),
+            patch("src.orchestrators.advanced.check_magentic_requirements"),
+        ):
+            orch = AdvancedOrchestrator()
             assert orch._max_rounds == 3
 
     def test_explicit_max_rounds_overrides_env(self) -> None:
         """Explicit parameter should override environment."""
-        with patch.dict(os.environ, {"ADVANCED_MAX_ROUNDS": "3"}):
-            orch = AdvancedOrchestrator.__new__(AdvancedOrchestrator)
-            orch.__init__(max_rounds=7)
+        with (
+            patch.dict(os.environ, {"ADVANCED_MAX_ROUNDS": "3"}),
+            patch("src.orchestrators.advanced.check_magentic_requirements"),
+        ):
+            orch = AdvancedOrchestrator(max_rounds=7)
             assert orch._max_rounds == 7
 
     def test_timeout_default_is_five_minutes(self) -> None:
         """Default timeout should be 300s (5 min) for faster failure."""
-        orch = AdvancedOrchestrator.__new__(AdvancedOrchestrator)
-        orch.__init__()
-        assert orch._timeout_seconds == 300.0
+        with patch("src.orchestrators.advanced.check_magentic_requirements"):
+            orch = AdvancedOrchestrator()
+            assert orch._timeout_seconds == 300.0
+
+    def test_invalid_env_rounds_falls_back_to_default(self) -> None:
+        """Invalid ADVANCED_MAX_ROUNDS should fall back to 5."""
+        with (
+            patch.dict(os.environ, {"ADVANCED_MAX_ROUNDS": "not_a_number"}),
+            patch("src.orchestrators.advanced.check_magentic_requirements"),
+        ):
+            orch = AdvancedOrchestrator()
+            assert orch._max_rounds == 5
+
+    def test_zero_env_rounds_clamps_to_one(self) -> None:
+        """ADVANCED_MAX_ROUNDS=0 should clamp to 1."""
+        with (
+            patch.dict(os.environ, {"ADVANCED_MAX_ROUNDS": "0"}),
+            patch("src.orchestrators.advanced.check_magentic_requirements"),
+        ):
+            orch = AdvancedOrchestrator()
+            assert orch._max_rounds == 1
+
+    def test_negative_env_rounds_clamps_to_one(self) -> None:
+        """Negative ADVANCED_MAX_ROUNDS should clamp to 1."""
+        with (
+            patch.dict(os.environ, {"ADVANCED_MAX_ROUNDS": "-5"}),
+            patch("src.orchestrators.advanced.check_magentic_requirements"),
+        ):
+            orch = AdvancedOrchestrator()
+            assert orch._max_rounds == 1


### PR DESCRIPTION
## Summary

Implements SPEC_15 - Advanced Mode Performance Optimization to reduce demo time from 10+ minutes to ~5 minutes.

### Solution A: Configurable Rounds
- Default `max_rounds` reduced from 10 to 5
- Configurable via `ADVANCED_MAX_ROUNDS` environment variable
- Explicit parameter overrides env var
- Default timeout reduced from 600s to 300s (5 min)

### Solution B: Early Termination Signal
- JudgeAgent now emits "✅ SUFFICIENT EVIDENCE" + "STOP SEARCHING" when confidence ≥70%
- Manager system prompt explicitly respects termination signal
- Allows workflow to exit early when evidence quality is adequate

### Solution C: Progress Indication
- Progress events show "Round X/Y (~Xm Xs remaining)"
- Initial thinking message shows estimated total time

## Files Changed
- `src/orchestrators/advanced.py` - Config options + progress + manager prompt
- `src/agents/magentic_agents.py` - JudgeAgent termination signal
- `tests/unit/orchestrators/test_advanced_orchestrator.py` - Config tests
- `examples/benchmark_advanced.py` - Timing benchmark

## Test Plan
- [x] Unit tests pass (4/4)
- [x] Full regression suite passes (297 tests)
- [x] Linting passes
- [x] Benchmark script runs and respects timeout

## Acceptance Criteria (from spec)
- [x] Default max_rounds is 5
- [x] max_rounds configurable via env var
- [x] Explicit param overrides env
- [x] Timeout is 300s
- [x] JudgeAgent emits termination signal
- [x] Manager respects signal
- [x] Progress shows round/max + time remaining

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark script for measuring Advanced mode orchestrator performance
  * Environment-driven configuration for maximum rounds (default: 5)

* **Improvements**
  * Reduced default timeout from 600 to 300 seconds
  * Enhanced progress tracking with estimated time remaining per round
  * Refined agent output structure for clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->