### PR TITLE
fix(deps): SPEC-18 Agent Framework Core Upgrade to 1.0.0b251204

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,5 @@ repos:
           - pydantic-settings>=2.2
           - tenacity>=8.2
           - pydantic-ai>=0.0.16
-          - agent-framework-core>=1.0.0b251120
+          - agent-framework-core==1.0.0b251204
         args: [--ignore-missing-imports]

--- a/docs/specs/SPEC_18_AGENT_FRAMEWORK_UPGRADE.md
+++ b/docs/specs/SPEC_18_AGENT_FRAMEWORK_UPGRADE.md
@@ -1,0 +1,459 @@
+# SPEC-18: Agent Framework Core Upgrade Strategy
+
+**Status**: APPROVED - Senior Review Complete
+**Created**: 2025-12-04
+**Priority**: P0 (Blocking HuggingFace Spaces deployment)
+**Estimated Effort**: 2-4 hours (implementation + testing)
+
+---
+
+## Executive Summary
+
+The `agent-framework-core` package released version `1.0.0b251204` on 2025-12-04 with breaking API changes. HuggingFace Spaces pulls this new version, breaking our app with:
+
+```
+cannot import name 'MagenticAgentDeltaEvent' from 'agent_framework'
+```
+
+**Key Insight**: The upstream release **FIXED the repr bug** that we reported and worked around with our Accumulator Pattern (SPEC-17). This creates an opportunity to simplify our codebase.
+
+**Recommendation**: UPGRADE to latest version (not pin to old) because:
+1. The repr bug fix means we can simplify our Accumulator Pattern
+2. Beta versions move fast - staying current is better long-term
+3. The migration is smaller than initially estimated (~30 lines to change)
+
+---
+
+## Root Cause Analysis
+
+### Why This Happened
+
+1. **Dependency drift**: Our `requirements.txt` used `>=1.0.0b251120,<2.0.0` (range)
+2. **New release**: Microsoft released `1.0.0b251204` on the SAME DAY (Dec 4, 2025)
+3. **HuggingFace behavior**: Fresh installs pull latest matching version
+4. **Breaking changes**: New version removed 3 event classes we depend on
+
+### Pattern Recognition
+
+This is the SECOND dependency-related P0 today:
+1. **MCP ToolUseContent** - Same pattern (requirements.txt drift)
+2. **Agent Framework events** - Same pattern (requirements.txt drift)
+
+**Lesson**: Beta dependencies need EXACT pinning, not ranges.
+
+---
+
+## Version Comparison
+
+| Version | Date | Status |
+|---------|------|--------|
+| `1.0.0b251120` | Nov 20, 2025 | Our current version (has repr bug) |
+| `1.0.0b251204` | Dec 4, 2025 | Latest (fixes repr bug, breaking API) |
+
+### What Microsoft Changed
+
+From [GitHub releases](https://github.com/microsoft/agent-framework/releases):
+
+1. **"Standardized orchestration outputs"** - Unified event system
+2. **"Fixed MagenticAgentExecutor from producing repr string"** - Our bug is fixed!
+3. **Event class refactoring** - Magentic-specific → Generic events
+
+---
+
+## API Changes (Complete Analysis)
+
+### Classes REMOVED (Breaking)
+
+```python
+# OLD (1.0.0b251120) - These no longer exist
+MagenticAgentDeltaEvent      # Streaming text chunks
+MagenticAgentMessageEvent    # Agent turn completion
+MagenticFinalResultEvent     # Final result
+```
+
+### Classes ADDED (Replacements)
+
+```python
+# NEW (1.0.0b251204) - Use these instead
+AgentRunUpdateEvent          # Streaming updates
+  └── .data: AgentRunResponseUpdate
+           └── .text: str          # Streaming text (same data!)
+           └── .contents: list     # Content blocks
+           └── .author_name: str   # Agent ID (was .agent_id)
+           └── .role: str          # Role (assistant, etc.)
+
+ExecutorCompletedEvent       # Agent turn complete (CRITICAL!)
+  └── .executor_id: str      # Which agent completed
+  └── .data: Any             # Completion data
+
+WorkflowOutputEvent          # Workflow finished (unchanged)
+```
+
+### Classes UNCHANGED
+
+```python
+# These work the same in both versions
+MagenticBuilder              ✅
+MagenticContext              ✅
+MagenticOrchestratorMessageEvent  ✅  # Still exists!
+WorkflowOutputEvent          ✅
+BaseChatClient               ✅
+ChatAgent                    ✅
+ai_function                  ✅
+```
+
+### Migration Mapping
+
+| OLD | NEW | Notes |
+|-----|-----|-------|
+| `MagenticAgentDeltaEvent.text` | `AgentRunUpdateEvent.data.text` | Same data, extra `.data` level |
+| `MagenticAgentDeltaEvent.agent_id` | `AgentRunUpdateEvent.data.author_name` | Renamed field |
+| `MagenticAgentMessageEvent` | `ExecutorCompletedEvent` | **CRITICAL**: Agent turn complete signal |
+| `MagenticAgentMessageEvent.agent_id` | `ExecutorCompletedEvent.executor_id` | Agent identifier |
+| `MagenticFinalResultEvent` | `WorkflowOutputEvent` | Workflow complete |
+| `MagenticOrchestratorMessageEvent` | `MagenticOrchestratorMessageEvent` | UNCHANGED ✅ |
+
+---
+
+## Files Requiring Changes
+
+### Critical (Must Change)
+
+| File | Lines | Changes Required |
+|------|-------|------------------|
+| `src/orchestrators/advanced.py` | 24-31, 327-385 | Import updates + event handling |
+| `tests/unit/orchestrators/test_accumulator_pattern.py` | 17-94 | Mock class updates |
+| `tests/unit/orchestrators/test_advanced_events.py` | 4 | Import update |
+| `requirements.txt` | 49 | Pin exact version |
+| `pyproject.toml` | 64 | Pin exact version |
+
+### Documentation (Update References)
+
+| File | Status | Action |
+|------|--------|--------|
+| `docs/workflow-diagrams.md` | Has old class names | Update diagram labels |
+| `docs/specs/archive/SPEC_17_ACCUMULATOR_PATTERN.md` | Archived | Add "Superseded" note |
+| `docs/bugs/archive/P0_REPR_BUG_ROOT_CAUSE_ANALYSIS.md` | Archived | Add "Fixed upstream" note |
+| `docs/architecture/system_registry.md` | Has outdated refs | Update tool inventory |
+
+### Config Files (Pin Versions)
+
+| File | Current | Change To |
+|------|---------|-----------|
+| `requirements.txt` | `>=1.0.0b251120,<2.0.0` | `==1.0.0b251204` |
+| `pyproject.toml` | `>=1.0.0b251120,<2.0.0` | `==1.0.0b251204` |
+| `uv.lock` | Auto-generated | Run `uv lock` after |
+
+---
+
+## Implementation Plan
+
+### Phase 1: Version Pinning (5 min)
+```bash
+# Update requirements.txt and pyproject.toml
+agent-framework-core==1.0.0b251204
+
+# Regenerate lock file
+uv lock
+uv sync
+```
+
+### Phase 2: Import Updates (10 min)
+
+**`src/orchestrators/advanced.py` lines 24-31:**
+```python
+# OLD
+from agent_framework import (
+    MagenticAgentDeltaEvent,
+    MagenticAgentMessageEvent,
+    MagenticBuilder,
+    MagenticFinalResultEvent,
+    MagenticOrchestratorMessageEvent,
+    WorkflowOutputEvent,
+)
+
+# NEW
+from agent_framework import (
+    AgentRunUpdateEvent,        # Replaces MagenticAgentDeltaEvent
+    ExecutorCompletedEvent,     # Replaces MagenticAgentMessageEvent (CRITICAL!)
+    MagenticBuilder,
+    MagenticOrchestratorMessageEvent,  # UNCHANGED
+    WorkflowOutputEvent,        # Replaces MagenticFinalResultEvent
+)
+```
+
+### Phase 3: Event Handling Refactor (30 min)
+
+**`src/orchestrators/advanced.py` lines 326-385:**
+
+```python
+# ============================================
+# 1. STREAMING: AgentRunUpdateEvent
+# ============================================
+# OLD:
+if isinstance(event, MagenticAgentDeltaEvent):
+    if event.text:
+        state.current_message_buffer += event.text
+        yield AgentEvent(type="streaming", message=event.text, ...)
+
+# NEW:
+if isinstance(event, AgentRunUpdateEvent) and event.data:
+    author = getattr(event.data, 'author_name', None)
+    if author != state.current_agent_id:
+        state.current_message_buffer = ""
+        state.current_agent_id = author
+
+    text = event.data.text
+    if text:
+        state.current_message_buffer += text
+        yield AgentEvent(type="streaming", message=text, data={"agent_id": author}, ...)
+    continue
+
+# ============================================
+# 2. COMPLETION SIGNAL: ExecutorCompletedEvent (CRITICAL!)
+# ============================================
+# OLD:
+if isinstance(event, MagenticAgentMessageEvent):
+    state.iteration += 1
+    # ... handle completion ...
+
+# NEW:
+if isinstance(event, ExecutorCompletedEvent):
+    state.iteration += 1
+    agent_name = event.executor_id or ""
+
+    # Track if ReportAgent ran (for P1 forced synthesis)
+    if REPORTER_AGENT_ID in agent_name.lower():
+        state.reporter_ran = True
+
+    # Use accumulated buffer (or trust event.data.text since repr bug is fixed)
+    comp_event, prog_event = self._handle_completion_event(
+        event, state.current_message_buffer, state.iteration
+    )
+    yield comp_event
+    yield prog_event
+    state.current_message_buffer = ""
+    continue
+
+# ============================================
+# 3. FINAL EVENT: WorkflowOutputEvent (unchanged pattern)
+# ============================================
+if isinstance(event, WorkflowOutputEvent):
+    # ... same as before, MagenticFinalResultEvent removed ...
+```
+
+**Key Simplification**: Since the repr bug is fixed upstream:
+1. We MAY be able to trust `event.data.text` directly
+2. Keep the buffer as safety net for this PR
+3. Mark Accumulator Pattern for potential removal in next sprint
+
+### Phase 4: Test Updates (30 min)
+
+**`tests/unit/orchestrators/test_accumulator_pattern.py`:**
+- Update mock classes to match new API
+- Verify Accumulator Pattern still works OR
+- Update tests if we simplify the pattern
+
+**`tests/unit/orchestrators/test_advanced_events.py`:**
+- Update import from `MagenticOrchestratorMessageEvent` (still exists)
+
+### Phase 5: Verification (30 min)
+
+```bash
+# Run full test suite
+make check
+
+# Verify specific tests
+uv run pytest tests/unit/orchestrators/ -v
+
+# Manual smoke test
+uv run python src/app.py
+# Test free tier (HuggingFace)
+# Test paid tier (OpenAI) if key available
+```
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| New bugs in event handling | MEDIUM | HIGH | Comprehensive test coverage |
+| Breaking streaming | LOW | HIGH | Keep buffer pattern as safety net |
+| Other API changes we missed | LOW | MEDIUM | Check all imports against new version |
+| HuggingFace caching old version | LOW | LOW | Use `--upgrade` flag |
+
+---
+
+## Rollback Plan
+
+If upgrade fails:
+1. Pin to OLD version: `agent-framework-core==1.0.0b251120`
+2. Keep existing Accumulator Pattern
+3. File issue with Microsoft if blocking bugs found
+
+---
+
+## Decision: Upgrade vs Pin Old
+
+### Option A: Upgrade to `1.0.0b251204` ✅ RECOMMENDED
+
+| Pros | Cons |
+|------|------|
+| Repr bug fixed upstream | Requires code changes |
+| Simpler codebase (maybe remove workaround) | Testing effort |
+| Aligned with upstream | Risk of new bugs |
+| Future-proof | |
+
+### Option B: Pin to `1.0.0b251120`
+
+| Pros | Cons |
+|------|------|
+| Zero code changes | Technical debt (keep workaround forever) |
+| Immediate fix | Missing bug fixes |
+| Known behavior | Eventually unsupported |
+
+**Recommendation**: **UPGRADE** - The effort is ~2-4 hours, but we get:
+1. Upstream repr bug fix (no more workaround needed)
+2. Cleaner codebase
+3. Alignment with Microsoft's direction
+
+---
+
+## Success Criteria
+
+- [ ] All 302 tests pass
+- [ ] `make check` passes (lint, type, test)
+- [ ] App starts on local
+- [ ] Free tier works (HuggingFace backend)
+- [ ] Paid tier works (OpenAI backend)
+- [ ] Streaming works correctly
+- [ ] No repr garbage in output
+- [ ] HuggingFace Spaces deployment works
+
+---
+
+## Post-Upgrade Cleanup
+
+After successful upgrade:
+1. Update `docs/specs/archive/SPEC_17_ACCUMULATOR_PATTERN.md` - Mark as "Superseded by upstream fix"
+2. Consider removing Accumulator Pattern if no longer needed
+3. Update `docs/architecture/system_registry.md` with new event classes
+4. Add regression test to prevent future dependency drift
+
+---
+
+## Appendix A: Full File Diff Preview
+
+### `src/orchestrators/advanced.py` (estimated diff)
+
+```diff
+ from agent_framework import (
+-    MagenticAgentDeltaEvent,
+-    MagenticAgentMessageEvent,
++    AgentRunUpdateEvent,
++    ExecutorCompletedEvent,
+     MagenticBuilder,
+-    MagenticFinalResultEvent,
+     MagenticOrchestratorMessageEvent,
+     WorkflowOutputEvent,
+ )
+
+ # ... lines 300-325 unchanged ...
+
+                     # 1. Handle Streaming
+-                    if isinstance(event, MagenticAgentDeltaEvent):
+-                        if event.agent_id != state.current_agent_id:
++                    if isinstance(event, AgentRunUpdateEvent) and event.data:
++                        author = getattr(event.data, 'author_name', None)
++                        if author != state.current_agent_id:
+                             state.current_message_buffer = ""
+-                            state.current_agent_id = event.agent_id
+-
+-                        if event.text:
+-                            state.current_message_buffer += event.text
++                            state.current_agent_id = author
++
++                        text = event.data.text
++                        if text:
++                            state.current_message_buffer += text
+                             yield AgentEvent(
+                                 type="streaming",
+-                                message=event.text,
+-                                data={"agent_id": event.agent_id},
++                                message=text,
++                                data={"agent_id": author},
+                                 iteration=state.iteration,
+                             )
+                         continue
+
+                     # 2. Handle Completion Signal
+-                    if isinstance(event, MagenticAgentMessageEvent):
++                    if isinstance(event, ExecutorCompletedEvent):
+                         state.iteration += 1
+-                        agent_name = (event.agent_id or "").lower()
++                        agent_name = (event.executor_id or "").lower()
+                         if REPORTER_AGENT_ID in agent_name:
+                             state.reporter_ran = True
+                         # ... rest of completion handling ...
+                         continue
+
+                     # 3. Handle Final Events
+-                    if isinstance(event, (MagenticFinalResultEvent, WorkflowOutputEvent)):
++                    if isinstance(event, WorkflowOutputEvent):
+                         # ... final event handling (remove MagenticFinalResultEvent check) ...
+```
+
+---
+
+## Appendix B: Lessons Learned
+
+### Dependency Management Best Practices
+
+1. **Beta packages need EXACT pins**: `==1.0.0b251204` not `>=1.0.0b251120`
+2. **Sync requirements.txt and pyproject.toml**: HuggingFace uses requirements.txt
+3. **Lock files are critical**: `uv.lock` captures exact versions
+4. **Monitor upstream releases**: Set up GitHub watch on critical deps
+
+### Why This Pattern Will Recur
+
+Microsoft Agent Framework is in **active beta** development. Expect:
+- Frequent releases (weekly/biweekly)
+- Breaking changes without major version bumps
+- API refactoring as they stabilize
+
+**Strategy**: Pin exact versions, upgrade deliberately, not automatically.
+
+---
+
+## Senior Agent Review: COMPLETE
+
+**Review conducted**: 2025-12-04
+
+### Questions & Answers:
+
+1. **Is the upgrade approach correct?**
+   ✅ YES - Upgrade is recommended. Pinning to old version would accumulate tech debt.
+
+2. **Are there any API changes we missed?**
+   ✅ FOUND: `ExecutorCompletedEvent` was missing from original spec.
+   - This is the replacement for `MagenticAgentMessageEvent` (agent turn completion)
+   - **CRITICAL** - Must be handled for proper workflow control
+
+3. **Should we keep the Accumulator Pattern as a safety net?**
+   ✅ YES for this PR - Keep buffer as safety net, mark for potential removal in next sprint.
+   - Upstream claims repr bug is fixed
+   - Verify with smoke test before removing workaround
+
+4. **Testing strategy for streaming behavior?**
+   ✅ Must include manual smoke test in addition to unit tests.
+   - Unit tests mock events, may not catch runtime issues
+   - Run `python src/app.py` and verify tokens stream correctly
+
+### Reviewer Notes:
+
+> "The analysis is accurate. The move to 'Standardized orchestration outputs' by Microsoft
+> explains the removal of Magentic-specific events in favor of generic AgentRun* events.
+> Proceed with the upgrade, ensuring ExecutorCompletedEvent is properly handled."
+
+**Status**: APPROVED FOR IMPLEMENTATION

--- a/docs/specs/SPEC_18_AGENT_FRAMEWORK_UPGRADE.md
+++ b/docs/specs/SPEC_18_AGENT_FRAMEWORK_UPGRADE.md
@@ -11,7 +11,7 @@
 
 The `agent-framework-core` package released version `1.0.0b251204` on 2025-12-04 with breaking API changes. HuggingFace Spaces pulls this new version, breaking our app with:
 
-```
+```text
 cannot import name 'MagenticAgentDeltaEvent' from 'agent_framework'
 ```
 

--- a/docs/workflow-diagrams.md
+++ b/docs/workflow-diagrams.md
@@ -499,9 +499,9 @@ graph TD
 
     Submit -.->|Triggers| Workflow[Magentic Workflow]
     Workflow -.->|MagenticOrchestratorMessageEvent| Log
-    Workflow -.->|MagenticAgentDeltaEvent| Log
-    Workflow -.->|MagenticAgentMessageEvent| Log
-    Workflow -.->|MagenticFinalResultEvent| Tab4
+    Workflow -.->|AgentRunUpdateEvent| Log
+    Workflow -.->|ExecutorCompletedEvent| Log
+    Workflow -.->|WorkflowOutputEvent| Tab4
 
     style App fill:#e1f5e1
     style Input fill:#fff4e6

--- a/docs/workflow-diagrams.md
+++ b/docs/workflow-diagrams.md
@@ -656,7 +656,7 @@ No separate Judge Agent needed - manager does it all!
 ---
 
 **Document Version**: 2.0 (Magentic Simplified)
-**Last Updated**: 2025-11-24
+**Last Updated**: 2025-12-05
 **Architecture**: Microsoft Magentic Orchestration Pattern
 **Agents**: 4 (Hypothesis, Search, Analysis, Report) + 1 Manager
 **License**: MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
     "pip-audit>=2.7.0",
 ]
 magentic = [
-    "agent-framework-core>=1.0.0b251120,<2.0.0",  # Microsoft Agent Framework (PyPI)
+    "agent-framework-core==1.0.0b251204",  # Microsoft Agent Framework (PyPI)
 ]
 rag = [
     # LlamaIndex RAG support (chromadb already in core deps)

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ langgraph-checkpoint-sqlite>=3.0.0,<4.0
 urllib3>=2.5.0
 
 # Multi-agent orchestration (Advanced mode) - from [magentic] optional
-agent-framework-core>=1.0.0b251120,<2.0.0
+agent-framework-core==1.0.0b251204
 
 # LlamaIndex RAG support - from [rag] optional
 llama-index>=0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # requirements.txt - HuggingFace Spaces Dependencies
 # ============================================================
 # This file MUST stay in sync with pyproject.toml dependencies.
-# Last synced: 2025-12-04
+# Last synced: 2025-12-05
 # ============================================================
 
 # Core

--- a/src/agents/graph/workflow.py
+++ b/src/agents/graph/workflow.py
@@ -25,7 +25,7 @@ def create_research_graph(
     llm: BaseChatModel | None = None,
     checkpointer: BaseCheckpointSaver[Any] | None = None,
     embedding_service: EmbeddingServiceProtocol | None = None,
-) -> CompiledStateGraph[Any]:
+) -> CompiledStateGraph[Any, Any, Any, Any]:
     """Build the research state graph.
 
     Args:

--- a/src/orchestrators/advanced.py
+++ b/src/orchestrators/advanced.py
@@ -22,11 +22,11 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
 from agent_framework import (
-    MagenticAgentDeltaEvent,
-    MagenticAgentMessageEvent,
+    MAGENTIC_EVENT_TYPE_ORCHESTRATOR,
+    AgentRunUpdateEvent,
+    ChatAgent,
+    ExecutorCompletedEvent,
     MagenticBuilder,
-    MagenticFinalResultEvent,
-    MagenticOrchestratorMessageEvent,
     WorkflowOutputEvent,
 )
 
@@ -150,6 +150,7 @@ class AdvancedOrchestrator(OrchestratorProtocol):
 
         # Manager chat client (orchestrates the agents)
         manager_client = self._chat_client
+        manager_agent = ChatAgent(chat_client=manager_client)
 
         return (
             MagenticBuilder()
@@ -160,7 +161,7 @@ class AdvancedOrchestrator(OrchestratorProtocol):
                 reporter=report_agent,
             )
             .with_standard_manager(
-                chat_client=manager_client,
+                agent=manager_agent,
                 max_round_count=self._max_rounds,
                 max_stall_count=3,
                 max_reset_count=2,
@@ -324,30 +325,33 @@ The final output should be a structured research report."""
             async with asyncio.timeout(self._timeout_seconds):
                 async for event in workflow.run_stream(task):
                     # 1. Handle Streaming (Source of Truth for Content)
-                    if isinstance(event, MagenticAgentDeltaEvent):
+                    if isinstance(event, AgentRunUpdateEvent) and event.data:
+                        author = getattr(event.data, "author_name", None)
                         # Detect agent switch to clear buffer
-                        if event.agent_id != state.current_agent_id:
+                        if author != state.current_agent_id:
                             state.current_message_buffer = ""
-                            state.current_agent_id = event.agent_id
+                            state.current_agent_id = author
 
-                        if event.text:
-                            state.current_message_buffer += event.text
+                        text = event.data.text
+                        if text:
+                            state.current_message_buffer += text
                             yield AgentEvent(
                                 type="streaming",
-                                message=event.text,
-                                data={"agent_id": event.agent_id},
+                                message=text,
+                                data={"agent_id": author},
                                 iteration=state.iteration,
                             )
                         continue
 
                     # 2. Handle Completion Signal
-                    # We use our accumulated buffer instead of the corrupted event.message
-                    if isinstance(event, MagenticAgentMessageEvent):
+                    if isinstance(event, ExecutorCompletedEvent):
                         state.iteration += 1
 
                         # P1 FIX: Track if ReportAgent produced output
-                        agent_name = (event.agent_id or "").lower()
-                        if REPORTER_AGENT_ID in agent_name:
+                        # Note: ExecutorCompletedEvent might not have agent_id directly accessible
+                        # The executor_id usually maps to the agent name
+                        agent_name = getattr(event, "executor_id", "") or "unknown"
+                        if REPORTER_AGENT_ID in agent_name.lower():
                             state.reporter_ran = True
 
                         comp_event, prog_event = self._handle_completion_event(
@@ -363,7 +367,7 @@ The final output should be a structured research report."""
                         continue
 
                     # 3. Handle Final Events Inline (P2 Duplicate Report Fix + P1 Forced Synthesis)
-                    if isinstance(event, (MagenticFinalResultEvent, WorkflowOutputEvent)):
+                    if isinstance(event, WorkflowOutputEvent):
                         if state.final_event_received:
                             continue  # Skip duplicate final events
                         state.final_event_received = True
@@ -430,21 +434,19 @@ The final output should be a structured research report."""
             )
 
     def _handle_completion_event(
-        self, event: MagenticAgentMessageEvent, buffer: str, iteration: int
+        self, event: ExecutorCompletedEvent, buffer: str, iteration: int
     ) -> tuple[AgentEvent, AgentEvent]:
         """Handle an agent completion event using the accumulated buffer."""
         # Use buffer if available, otherwise fall back cautiously
         # (Only fall back if buffer empty, which implies tool-only turn)
         text_content = buffer
         if not text_content:
+            # ExecutorCompletedEvent doesn't carry the message directly in the same way
             # Try extraction but ignore repr strings AND empty strings
-            raw_text = self._extract_text(event.message)
-            if raw_text and not (raw_text.startswith("<") and "object at" in raw_text):
-                text_content = raw_text
-            else:
-                text_content = "Action completed (Tool Call)"
+            # The result is often in event.result or similar, but buffering is safer
+            text_content = "Action completed (Tool Call)"
 
-        agent_name = event.agent_id or "unknown"
+        agent_name = getattr(event, "executor_id", "unknown") or "unknown"
         event_type = self._get_event_type_for_agent(agent_name)
 
         completion_event = AgentEvent(
@@ -470,7 +472,7 @@ The final output should be a structured research report."""
 
     def _handle_final_event(
         self,
-        event: MagenticFinalResultEvent | WorkflowOutputEvent,
+        event: WorkflowOutputEvent,
         iteration: int,
         last_streamed_length: int,
     ) -> AgentEvent:
@@ -490,9 +492,7 @@ The final output should be a structured research report."""
 
         # NO: Final event must carry the payload (tool-only turn, cache hit)
         text = ""
-        if isinstance(event, MagenticFinalResultEvent):
-            text = self._extract_text(event.message) if event.message else "No result"
-        elif isinstance(event, WorkflowOutputEvent):
+        if isinstance(event, WorkflowOutputEvent):
             text = self._extract_text(event.data) if event.data else "Research complete"
 
         return AgentEvent(
@@ -589,14 +589,19 @@ The final output should be a structured research report."""
 
     def _process_event(self, event: Any, iteration: int) -> AgentEvent | None:
         """Process workflow event into AgentEvent."""
-        if isinstance(event, MagenticOrchestratorMessageEvent):
+        # Handle orchestrator messages (formerly MagenticOrchestratorMessageEvent)
+        # We check the event type string directly
+        if getattr(event, "type", "") == MAGENTIC_EVENT_TYPE_ORCHESTRATOR:
+            kind = getattr(event, "kind", "")
+            message = getattr(event, "message", "")
+
             # FILTERING: Skip internal framework bookkeeping
-            if event.kind in ("task_ledger", "instruction"):
+            if kind in ("task_ledger", "instruction"):
                 return None
 
             # TRANSFORMATION: Handle user_task BEFORE text extraction
             # (user_task uses static message, doesn't need text content)
-            if event.kind == "user_task":
+            if kind == "user_task":
                 return AgentEvent(
                     type="progress",
                     message="Manager assigning research task to agents...",
@@ -604,23 +609,22 @@ The final output should be a structured research report."""
                 )
 
             # For other manager events, extract and validate text
-            text = self._extract_text(event.message)
+            text = self._extract_text(message)
             if not text:
                 return None
 
             # Default fallback for other manager events
             return AgentEvent(
                 type="judging",
-                message=f"Manager ({event.kind}): {self._smart_truncate(text)}",
+                message=f"Manager ({kind}): {self._smart_truncate(text)}",
                 iteration=iteration,
             )
 
         # NOTE: The following event types are handled inline in run() loop and never reach
         # this method due to `continue` statements:
-        # - MagenticAgentMessageEvent: Accumulator Pattern (lines 322-335)
-        # - MagenticAgentDeltaEvent: Accumulator Pattern (lines 306-320)
-        # - MagenticFinalResultEvent: P2 Duplicate Fix via _handle_final_event() (lines 343-347)
-        # - WorkflowOutputEvent: P2 Duplicate Fix via _handle_final_event() (lines 343-347)
+        # - ExecutorCompletedEvent: Accumulator Pattern
+        # - AgentRunUpdateEvent: Accumulator Pattern
+        # - WorkflowOutputEvent: P2 Duplicate Fix via _handle_final_event()
 
         return None
 

--- a/src/orchestrators/advanced.py
+++ b/src/orchestrators/advanced.py
@@ -332,7 +332,7 @@ The final output should be a structured research report."""
                             state.current_message_buffer = ""
                             state.current_agent_id = author
 
-                        text = event.data.text
+                        text = getattr(event.data, "text", None)
                         if text:
                             state.current_message_buffer += text
                             yield AgentEvent(
@@ -491,9 +491,7 @@ The final output should be a structured research report."""
             )
 
         # NO: Final event must carry the payload (tool-only turn, cache hit)
-        text = ""
-        if isinstance(event, WorkflowOutputEvent):
-            text = self._extract_text(event.data) if event.data else "Research complete"
+        text = self._extract_text(event.data) if event.data else "Research complete"
 
         return AgentEvent(
             type="complete",

--- a/tests/unit/orchestrators/test_accumulator_pattern.py
+++ b/tests/unit/orchestrators/test_accumulator_pattern.py
@@ -1,8 +1,13 @@
 """
 Test the Accumulator Pattern for Microsoft Agent Framework event handling.
 
-This tests SPEC 17: We use MagenticAgentDeltaEvent.text as the sole source of content,
-and MagenticAgentMessageEvent as a signal only (ignoring .message to avoid repr bug).
+This tests SPEC-17 (updated for SPEC-18): We use AgentRunUpdateEvent.data.text as the
+sole source of streaming content, and ExecutorCompletedEvent as a completion signal.
+
+Event mapping (SPEC-18 migration):
+- MagenticAgentDeltaEvent → AgentRunUpdateEvent
+- MagenticAgentMessageEvent → ExecutorCompletedEvent
+- MagenticFinalResultEvent → WorkflowOutputEvent
 """
 
 import importlib

--- a/tests/unit/orchestrators/test_accumulator_pattern.py
+++ b/tests/unit/orchestrators/test_accumulator_pattern.py
@@ -14,40 +14,20 @@ import pytest
 
 
 # --- Create real event classes ---
-class MockDeltaEvent:
-    """Simulates MagenticAgentDeltaEvent with streaming text."""
+class MockAgentRunUpdateEvent:
+    """Simulates AgentRunUpdateEvent with streaming data."""
 
-    def __init__(self, text: str, agent_id: str = "TestAgent"):
-        self.text = text
-        self.agent_id = agent_id
-
-
-class MockMessageEvent:
-    """Simulates MagenticAgentMessageEvent with potentially corrupted .message."""
-
-    def __init__(self, message_text: str, agent_id: str = "TestAgent"):
-        self.message = MagicMock()
-        self.message.text = message_text  # This could be repr garbage
-        self.agent_id = agent_id
-        self.text = None  # No top-level .text on MessageEvent
+    def __init__(self, text: str, author_name: str = "TestAgent"):
+        self.data = MagicMock()
+        self.data.text = text
+        self.data.author_name = author_name
 
 
-class MockFinalResultEvent:
-    """Simulates MagenticFinalResultEvent."""
+class MockExecutorCompletedEvent:
+    """Simulates ExecutorCompletedEvent signaling agent turn completion."""
 
-    def __init__(self, text: str):
-        self.message = MagicMock()
-        self.message.text = text
-        self.text = None
-
-
-class MockOrchestratorMessageEvent:
-    """Simulates MagenticOrchestratorMessageEvent."""
-
-    def __init__(self, kind: str = "user_task", message: str = "test"):
-        self.kind = kind
-        self.message = MagicMock()
-        self.message.text = message
+    def __init__(self, executor_id: str = "TestAgent"):
+        self.executor_id = executor_id
 
 
 class MockWorkflowOutputEvent:
@@ -55,6 +35,18 @@ class MockWorkflowOutputEvent:
 
     def __init__(self, data=None):
         self.data = data
+
+
+class MockOrchestratorMessageEvent:
+    """Simulates orchestrator message event (formerly MagenticOrchestratorMessageEvent)."""
+
+    def __init__(self, kind: str = "user_task", message: str = "test"):
+        from agent_framework import MAGENTIC_EVENT_TYPE_ORCHESTRATOR
+
+        self.type = MAGENTIC_EVENT_TYPE_ORCHESTRATOR
+        self.kind = kind
+        self.message = MagicMock()
+        self.message.text = message
 
 
 # Pass-through decorators
@@ -87,11 +79,12 @@ def mock_agent_framework():
     mock_af.observability = mock_af_observability
 
     # Assign our REAL event classes as the module-level types
-    mock_af.MagenticAgentDeltaEvent = MockDeltaEvent
-    mock_af.MagenticAgentMessageEvent = MockMessageEvent
-    mock_af.MagenticFinalResultEvent = MockFinalResultEvent
-    mock_af.MagenticOrchestratorMessageEvent = MockOrchestratorMessageEvent
+    mock_af.AgentRunUpdateEvent = MockAgentRunUpdateEvent
+    mock_af.ExecutorCompletedEvent = MockExecutorCompletedEvent
     mock_af.WorkflowOutputEvent = MockWorkflowOutputEvent
+    mock_af.MagenticOrchestratorMessageEvent = MockOrchestratorMessageEvent
+    mock_af.AgentRunResponse = MagicMock
+    mock_af.MAGENTIC_EVENT_TYPE_ORCHESTRATOR = "orchestrator_message"
 
     # Mock other classes
     mock_af.MagenticBuilder = MagicMock
@@ -173,13 +166,13 @@ def mock_orchestrator(mock_agent_framework):
 async def test_accumulator_pattern_scenario_a_standard_text(mock_orchestrator):
     """
     Scenario A: Standard Text Message
-    Input: Deltas ("Hello", " World") -> MessageEvent (Poisoned Repr)
-    Expected: AgentEvent with "Hello World", NOT the repr string
+    Input: Updates ("Hello", " World") -> Completed
+    Expected: AgentEvent with "Hello World"
     """
     events = [
-        MockDeltaEvent("Hello", agent_id="ChatBot"),
-        MockDeltaEvent(" World", agent_id="ChatBot"),
-        MockMessageEvent("<ChatMessage object at 0xDEADBEEF>", agent_id="ChatBot"),
+        MockAgentRunUpdateEvent("Hello", author_name="ChatBot"),
+        MockAgentRunUpdateEvent(" World", author_name="ChatBot"),
+        MockExecutorCompletedEvent(executor_id="ChatBot"),
     ]
 
     async def mock_stream(*args, **kwargs):
@@ -204,9 +197,8 @@ async def test_accumulator_pattern_scenario_a_standard_text(mock_orchestrator):
     )
     final_event = chat_events[0]
 
-    # CRITICAL: Must contain accumulated text, NOT repr
+    # Must contain accumulated text
     assert "Hello World" in final_event.message or "Hello" in final_event.message
-    assert "<ChatMessage" not in final_event.message, f"Repr bug! Got: {final_event.message}"
 
 
 @pytest.mark.unit
@@ -214,11 +206,11 @@ async def test_accumulator_pattern_scenario_a_standard_text(mock_orchestrator):
 async def test_accumulator_pattern_scenario_b_tool_call(mock_orchestrator):
     """
     Scenario B: Tool Call (No Text Deltas)
-    Input: No Deltas -> MessageEvent (Poisoned Repr)
-    Expected: AgentEvent with fallback text, NOT the repr string
+    Input: No Deltas -> Completed
+    Expected: AgentEvent with fallback text
     """
     events = [
-        MockMessageEvent("<ChatMessage object at 0xDEADBEEF>", agent_id="SearchAgent"),
+        MockExecutorCompletedEvent(executor_id="SearchAgent"),
     ]
 
     async def mock_stream(*args, **kwargs):
@@ -243,8 +235,6 @@ async def test_accumulator_pattern_scenario_b_tool_call(mock_orchestrator):
     )
     final_event = search_events[0]
 
-    # CRITICAL: Should use fallback, NOT repr
-    assert "<ChatMessage" not in final_event.message, f"Repr bug! Got: {final_event.message}"
     # Should contain fallback or tool indicator
     assert "Action completed" in final_event.message or "Tool" in final_event.message
 
@@ -257,10 +247,10 @@ async def test_accumulator_pattern_buffer_clearing(mock_orchestrator):
     Agent B should NOT inherit Agent A's accumulated text.
     """
     events = [
-        MockDeltaEvent("Agent A says hi", agent_id="AgentA"),
-        MockMessageEvent("irrelevant", agent_id="AgentA"),
-        MockDeltaEvent("Agent B responds", agent_id="AgentB"),
-        MockMessageEvent("irrelevant", agent_id="AgentB"),
+        MockAgentRunUpdateEvent("Agent A says hi", author_name="AgentA"),
+        MockExecutorCompletedEvent(executor_id="AgentA"),
+        MockAgentRunUpdateEvent("Agent B responds", author_name="AgentB"),
+        MockExecutorCompletedEvent(executor_id="AgentB"),
     ]
 
     async def mock_stream(*args, **kwargs):

--- a/tests/unit/orchestrators/test_advanced_events.py
+++ b/tests/unit/orchestrators/test_advanced_events.py
@@ -1,9 +1,21 @@
 """Test for AdvancedOrchestrator event processing (P1 Bug)."""
 
+from unittest.mock import MagicMock
+
 import pytest
-from agent_framework import MagenticOrchestratorMessageEvent
+from agent_framework import MAGENTIC_EVENT_TYPE_ORCHESTRATOR
 
 from src.orchestrators.advanced import AdvancedOrchestrator
+
+
+class MockOrchestratorEvent:
+    """Mock event that mimics the new orchestrator event structure."""
+
+    def __init__(self, kind: str, message: str):
+        self.type = MAGENTIC_EVENT_TYPE_ORCHESTRATOR
+        self.kind = kind
+        self.message = MagicMock()
+        self.message.text = message
 
 
 @pytest.mark.unit
@@ -28,7 +40,7 @@ class TestAdvancedEventProcessing:
         Desired behavior: Returns None (filtered)
         """
         # Create a raw internal framework event
-        raw_event = MagenticOrchestratorMessageEvent(
+        raw_event = MockOrchestratorEvent(
             kind="task_ledger",
             message="We are working to address the following user request: Research sildenafil...",
         )
@@ -46,7 +58,7 @@ class TestAdvancedEventProcessing:
         Current behavior: Returns AgentEvent(type='judging', message='Manager (instruction): ...')
         Desired behavior: Returns None (filtered)
         """
-        raw_event = MagenticOrchestratorMessageEvent(
+        raw_event = MockOrchestratorEvent(
             kind="instruction", message="Conduct targeted searches on PubMed..."
         )
 
@@ -61,7 +73,7 @@ class TestAdvancedEventProcessing:
         Current behavior: 'Manager (user_task): Research...' (truncated, type='judging')
         Desired behavior: 'Manager assigning research task...' (type='progress')
         """
-        raw_event = MagenticOrchestratorMessageEvent(
+        raw_event = MockOrchestratorEvent(
             kind="user_task",
             message="Research sexual health and wellness interventions for: sildenafil mechanism",
         )

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework-core"
-version = "1.0.0b251120"
+version = "1.0.0b251204"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-identity" },
@@ -36,9 +36,9 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/78/c53cb3a657ca5e000ce196c6ca776eb5b5cd95cbd8ac691872b8cc4ea23c/agent_framework_core-1.0.0b251120.tar.gz", hash = "sha256:eb327c123ce54ff36ccc828bcc4f5162248f768f2438be0550644f1b3c28927f", size = 281920 }
+sdist = { url = "https://files.pythonhosted.org/packages/09/6c/0dc008b80e04814e68b89f843d910f75d05e0fe28094cad311af802f1bcf/agent_framework_core-1.0.0b251204.tar.gz", hash = "sha256:846f87b83b0772de4b9812b2659d1d0e3185a86329ae9347ead201fb15161e51", size = 290590 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/60/7e40edfa60372cf0d56500b19c6bb322ca483fd4e7b558c1bf0ff88d4540/agent_framework_core-1.0.0b251120-py3-none-any.whl", hash = "sha256:65618ad496fa6805992980f2801b8d1a226e8edc59974945bb903df917fda105", size = 326665 },
+    { url = "https://files.pythonhosted.org/packages/e5/87/4381b35da5a6b1388ad714f83a2f5ad3b382ccdd397beb1a3e2f75b62a5b/agent_framework_core-1.0.0b251204-py3-none-any.whl", hash = "sha256:feb06ce3a146ab4e7793a389b5f74982391ed03feb98954fa9991a22a48cbdb5", size = 334273 },
 ]
 
 [[package]]
@@ -1130,7 +1130,7 @@ rag = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework-core", marker = "extra == 'magentic'", specifier = ">=1.0.0b251120,<2.0.0" },
+    { name = "agent-framework-core", marker = "extra == 'magentic'", specifier = "==1.0.0b251204" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "chromadb", specifier = ">=0.4.22" },
@@ -2684,7 +2684,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.15.1"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "executing" },
@@ -2695,9 +2695,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/7b/3cdbfbd8fc085912d7322afc5f16ffd396197574fc9c786422b0ce3f5232/logfire-4.15.1.tar.gz", hash = "sha256:fac8463c0319af6d1bf66788802ff0a04b481dac006564f6837f64c7404f474a", size = 549319 }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/60/b8040db3598a55da64c45e3e689f2baa87389a4648a6f46ba80be3329f23/logfire-4.16.0.tar.gz", hash = "sha256:03a3ab8fdc13399309cb55d69cba7a6fcbad3526cfad85fc4f72e7d75e22b654", size = 550759 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/44/45c39998cb3920a11498455f3f62f173bd3f5d9a15bd0db40f88bedb9e1f/logfire-4.15.1-py3-none-any.whl", hash = "sha256:b931d2becf937c08d7c89f1ab68ab05298095b010dfaf29cbd22f7bcacbaa2bb", size = 228716 },
+    { url = "https://files.pythonhosted.org/packages/53/f7/ffcf81eb4aea75e40c0646b9519947d2070626c5d533922df92975045181/logfire-4.16.0-py3-none-any.whl", hash = "sha256:8f895f6c2efa593ad6d49e1b06d8e6e351d3dd0cad61ce5def0c3d401f8ea707", size = 229122 },
 ]
 
 [package.optional-dependencies]
@@ -3671,32 +3671,32 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.38.0"
+version = "1.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/d8/0f354c375628e048bd0570645b310797299754730079853095bf000fba69/opentelemetry_api-1.38.0.tar.gz", hash = "sha256:f4c193b5e8acb0912b06ac5b16321908dd0843d75049c091487322284a3eea12", size = 65242 }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/0b/e5428c009d4d9af0515b0a8371a8aaae695371af291f45e702f7969dce6b/opentelemetry_api-1.39.0.tar.gz", hash = "sha256:6130644268c5ac6bdffaf660ce878f10906b3e789f7e2daa5e169b047a2933b9", size = 65763 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/a2/d86e01c28300bd41bab8f18afd613676e2bd63515417b77636fc1add426f/opentelemetry_api-1.38.0-py3-none-any.whl", hash = "sha256:2891b0197f47124454ab9f0cf58f3be33faca394457ac3e09daba13ff50aa582", size = 65947 },
+    { url = "https://files.pythonhosted.org/packages/05/85/d831a9bc0a9e0e1a304ff3d12c1489a5fbc9bf6690a15dcbdae372bbca45/opentelemetry_api-1.39.0-py3-none-any.whl", hash = "sha256:3c3b3ca5c5687b1b5b37e5c5027ff68eacea8675241b29f13110a8ffbb8f0459", size = 66357 },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.38.0"
+version = "1.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/83/dd4660f2956ff88ed071e9e0e36e830df14b8c5dc06722dbde1841accbe8/opentelemetry_exporter_otlp_proto_common-1.38.0.tar.gz", hash = "sha256:e333278afab4695aa8114eeb7bf4e44e65c6607d54968271a249c180b2cb605c", size = 20431 }
+sdist = { url = "https://files.pythonhosted.org/packages/11/cb/3a29ce606b10c76d413d6edd42d25a654af03e73e50696611e757d2602f3/opentelemetry_exporter_otlp_proto_common-1.39.0.tar.gz", hash = "sha256:a135fceed1a6d767f75be65bd2845da344dd8b9258eeed6bc48509d02b184409", size = 20407 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/9e/55a41c9601191e8cd8eb626b54ee6827b9c9d4a46d736f32abc80d8039fc/opentelemetry_exporter_otlp_proto_common-1.38.0-py3-none-any.whl", hash = "sha256:03cb76ab213300fe4f4c62b7d8f17d97fcfd21b89f0b5ce38ea156327ddda74a", size = 18359 },
+    { url = "https://files.pythonhosted.org/packages/ef/c6/215edba62d13a3948c718b289539f70e40965bc37fc82ecd55bb0b749c1a/opentelemetry_exporter_otlp_proto_common-1.39.0-py3-none-any.whl", hash = "sha256:3d77be7c4bdf90f1a76666c934368b8abed730b5c6f0547a2ec57feb115849ac", size = 18367 },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.38.0"
+version = "1.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -3707,14 +3707,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/c0/43222f5b97dc10812bc4f0abc5dc7cd0a2525a91b5151d26c9e2e958f52e/opentelemetry_exporter_otlp_proto_grpc-1.38.0.tar.gz", hash = "sha256:2473935e9eac71f401de6101d37d6f3f0f1831db92b953c7dcc912536158ebd6", size = 24676 }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/62/4db083ee9620da3065eeb559e9fc128f41a1d15e7c48d7c83aafbccd354c/opentelemetry_exporter_otlp_proto_grpc-1.39.0.tar.gz", hash = "sha256:7e7bb3f436006836c0e0a42ac619097746ad5553ad7128a5bd4d3e727f37fc06", size = 24650 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/f0/bd831afbdba74ca2ce3982142a2fad707f8c487e8a3b6fef01f1d5945d1b/opentelemetry_exporter_otlp_proto_grpc-1.38.0-py3-none-any.whl", hash = "sha256:7c49fd9b4bd0dbe9ba13d91f764c2d20b0025649a6e4ac35792fb8d84d764bc7", size = 19695 },
+    { url = "https://files.pythonhosted.org/packages/56/e8/d420b94ffddfd8cff85bb4aa5d98da26ce7935dc3cf3eca6b83cd39ab436/opentelemetry_exporter_otlp_proto_grpc-1.39.0-py3-none-any.whl", hash = "sha256:758641278050de9bb895738f35ff8840e4a47685b7e6ef4a201fe83196ba7a05", size = 19765 },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.38.0"
+version = "1.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -3725,14 +3725,14 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/0a/debcdfb029fbd1ccd1563f7c287b89a6f7bef3b2902ade56797bfd020854/opentelemetry_exporter_otlp_proto_http-1.38.0.tar.gz", hash = "sha256:f16bd44baf15cbe07633c5112ffc68229d0edbeac7b37610be0b2def4e21e90b", size = 17282 }
+sdist = { url = "https://files.pythonhosted.org/packages/81/dc/1e9bf3f6a28e29eba516bc0266e052996d02bc7e92675f3cd38169607609/opentelemetry_exporter_otlp_proto_http-1.39.0.tar.gz", hash = "sha256:28d78fc0eb82d5a71ae552263d5012fa3ebad18dfd189bf8d8095ba0e65ee1ed", size = 17287 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/77/154004c99fb9f291f74aa0822a2f5bbf565a72d8126b3a1b63ed8e5f83c7/opentelemetry_exporter_otlp_proto_http-1.38.0-py3-none-any.whl", hash = "sha256:84b937305edfc563f08ec69b9cb2298be8188371217e867c1854d77198d0825b", size = 19579 },
+    { url = "https://files.pythonhosted.org/packages/bc/46/e4a102e17205bb05a50dbf24ef0e92b66b648cd67db9a68865af06a242fd/opentelemetry_exporter_otlp_proto_http-1.39.0-py3-none-any.whl", hash = "sha256:5789cb1375a8b82653328c0ce13a054d285f774099faf9d068032a49de4c7862", size = 19639 },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.59b0"
+version = "0.60b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3740,14 +3740,14 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ed/9c65cd209407fd807fa05be03ee30f159bdac8d59e7ea16a8fe5a1601222/opentelemetry_instrumentation-0.59b0.tar.gz", hash = "sha256:6010f0faaacdaf7c4dff8aac84e226d23437b331dcda7e70367f6d73a7db1adc", size = 31544 }
+sdist = { url = "https://files.pythonhosted.org/packages/55/3c/bd53dbb42eff93d18e3047c7be11224aa9966ce98ac4cc5bfb860a32c95a/opentelemetry_instrumentation-0.60b0.tar.gz", hash = "sha256:4e9fec930f283a2677a2217754b40aaf9ef76edae40499c165bc7f1d15366a74", size = 31707 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/f5/7a40ff3f62bfe715dad2f633d7f1174ba1a7dd74254c15b2558b3401262a/opentelemetry_instrumentation-0.59b0-py3-none-any.whl", hash = "sha256:44082cc8fe56b0186e87ee8f7c17c327c4c2ce93bdbe86496e600985d74368ee", size = 33020 },
+    { url = "https://files.pythonhosted.org/packages/5c/7b/5b5b9f8cfe727a28553acf9cd287b1d7f706f5c0a00d6e482df55b169483/opentelemetry_instrumentation-0.60b0-py3-none-any.whl", hash = "sha256:aaafa1483543a402819f1bdfb06af721c87d60dd109501f9997332862a35c76a", size = 33096 },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-httpx"
-version = "0.59b0"
+version = "0.60b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3756,48 +3756,48 @@ dependencies = [
     { name = "opentelemetry-util-http" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/6b/1bdf36b68cace9b4eae3cbbade4150c71c90aa392b127dda5bb5c2a49307/opentelemetry_instrumentation_httpx-0.59b0.tar.gz", hash = "sha256:a1cb9b89d9f05a82701cc9ab9cfa3db54fd76932489449778b350bc1b9f0e872", size = 19886 }
+sdist = { url = "https://files.pythonhosted.org/packages/09/71/9dc0bc5ab14122251f520ffe9fc8dd892ca688d7d591482b5b1843d685d2/opentelemetry_instrumentation_httpx-0.60b0.tar.gz", hash = "sha256:fcf349a92fb0b941a2a18bec65141f4ba62cbf7a457a1aa580794bad44dc477c", size = 20612 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/16/c1e0745d20af392ec9060693531d7f01239deb2d81e460d0c379719691b8/opentelemetry_instrumentation_httpx-0.59b0-py3-none-any.whl", hash = "sha256:7dc9f66aef4ca3904d877f459a70c78eafd06131dc64d713b9b1b5a7d0a48f05", size = 15197 },
+    { url = "https://files.pythonhosted.org/packages/3a/22/a340c8bfad6f31bfd6a15b0b24d5e68e05e3975e4dbdc3cea6ec4f96e060/opentelemetry_instrumentation_httpx-0.60b0-py3-none-any.whl", hash = "sha256:3f5e6fc4ddf1d9de2aaddb5255110827154dbd4de9187da906c8c2a3cc2219e9", size = 15702 },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.38.0"
+version = "1.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/14/f0c4f0f6371b9cb7f9fa9ee8918bfd59ac7040c7791f1e6da32a1839780d/opentelemetry_proto-1.38.0.tar.gz", hash = "sha256:88b161e89d9d372ce723da289b7da74c3a8354a8e5359992be813942969ed468", size = 46152 }
+sdist = { url = "https://files.pythonhosted.org/packages/48/b5/64d2f8c3393cd13ea2092106118f7b98461ba09333d40179a31444c6f176/opentelemetry_proto-1.39.0.tar.gz", hash = "sha256:c1fa48678ad1a1624258698e59be73f990b7fc1f39e73e16a9d08eef65dd838c", size = 46153 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/6a/82b68b14efca5150b2632f3692d627afa76b77378c4999f2648979409528/opentelemetry_proto-1.38.0-py3-none-any.whl", hash = "sha256:b6ebe54d3217c42e45462e2a1ae28c3e2bf2ec5a5645236a490f55f45f1a0a18", size = 72535 },
+    { url = "https://files.pythonhosted.org/packages/e3/4d/d500e1862beed68318705732d1976c390f4a72ca8009c4983ff627acff20/opentelemetry_proto-1.39.0-py3-none-any.whl", hash = "sha256:1e086552ac79acb501485ff0ce75533f70f3382d43d0a30728eeee594f7bf818", size = 72534 },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.38.0"
+version = "1.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/cb/f0eee1445161faf4c9af3ba7b848cc22a50a3d3e2515051ad8628c35ff80/opentelemetry_sdk-1.38.0.tar.gz", hash = "sha256:93df5d4d871ed09cb4272305be4d996236eedb232253e3ab864c8620f051cebe", size = 171942 }
+sdist = { url = "https://files.pythonhosted.org/packages/51/e3/7cd989003e7cde72e0becfe830abff0df55c69d237ee7961a541e0167833/opentelemetry_sdk-1.39.0.tar.gz", hash = "sha256:c22204f12a0529e07aa4d985f1bca9d6b0e7b29fe7f03e923548ae52e0e15dde", size = 171322 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/2e/e93777a95d7d9c40d270a371392b6d6f1ff170c2a3cb32d6176741b5b723/opentelemetry_sdk-1.38.0-py3-none-any.whl", hash = "sha256:1c66af6564ecc1553d72d811a01df063ff097cdc82ce188da9951f93b8d10f6b", size = 132349 },
+    { url = "https://files.pythonhosted.org/packages/a4/b4/2adc8bc83eb1055ecb592708efb6f0c520cc2eb68970b02b0f6ecda149cf/opentelemetry_sdk-1.39.0-py3-none-any.whl", hash = "sha256:90cfb07600dfc0d2de26120cebc0c8f27e69bf77cd80ef96645232372709a514", size = 132413 },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.59b0"
+version = "0.60b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/bc/8b9ad3802cd8ac6583a4eb7de7e5d7db004e89cb7efe7008f9c8a537ee75/opentelemetry_semantic_conventions-0.59b0.tar.gz", hash = "sha256:7a6db3f30d70202d5bf9fa4b69bc866ca6a30437287de6c510fb594878aed6b0", size = 129861 }
+sdist = { url = "https://files.pythonhosted.org/packages/71/0e/176a7844fe4e3cb5de604212094dffaed4e18b32f1c56b5258bcbcba85c2/opentelemetry_semantic_conventions-0.60b0.tar.gz", hash = "sha256:227d7aa73cbb8a2e418029d6b6465553aa01cf7e78ec9d0bc3255c7b3ac5bf8f", size = 137935 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/7d/c88d7b15ba8fe5c6b8f93be50fc11795e9fc05386c44afaf6b76fe191f9b/opentelemetry_semantic_conventions-0.59b0-py3-none-any.whl", hash = "sha256:35d3b8833ef97d614136e253c1da9342b4c3c083bbaf29ce31d572a1c3825eed", size = 207954 },
+    { url = "https://files.pythonhosted.org/packages/d0/56/af0306666f91bae47db14d620775604688361f0f76a872e0005277311131/opentelemetry_semantic_conventions-0.60b0-py3-none-any.whl", hash = "sha256:069530852691136018087b52688857d97bba61cd641d0f8628d2d92788c4f78a", size = 219981 },
 ]
 
 [[package]]
@@ -3811,11 +3811,11 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.59b0"
+version = "0.60b0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/f7/13cd081e7851c42520ab0e96efb17ffbd901111a50b8252ec1e240664020/opentelemetry_util_http-0.59b0.tar.gz", hash = "sha256:ae66ee91be31938d832f3b4bc4eb8a911f6eddd38969c4a871b1230db2a0a560", size = 9412 }
+sdist = { url = "https://files.pythonhosted.org/packages/38/0d/786a713445cf338131fef3a84fab1378e4b2ef3c3ea348eeb0c915eb804a/opentelemetry_util_http-0.60b0.tar.gz", hash = "sha256:e42b7bb49bba43b6f34390327d97e5016eb1c47949ceaf37c4795472a4e3a82d", size = 10576 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/56/62282d1d4482061360449dacc990c89cad0fc810a2ed937b636300f55023/opentelemetry_util_http-0.59b0-py3-none-any.whl", hash = "sha256:6d036a07563bce87bf521839c0671b507a02a0d39d7ea61b88efa14c6e25355d", size = 7648 },
+    { url = "https://files.pythonhosted.org/packages/53/5d/a448862f6d10c95685ed0e703596b6bd1784074e7ad90bffdc550abb7b68/opentelemetry_util_http-0.60b0-py3-none-any.whl", hash = "sha256:4f366f1a48adb74ffa6f80aee26f96882e767e01b03cd1cfb948b6e1020341fe", size = 8742 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**P0 Bug Fix**: HuggingFace Spaces deployment blocked by breaking API changes in `agent-framework-core`.

Microsoft released `1.0.0b251204` on Dec 4, 2025 with breaking changes:
- `MagenticAgentDeltaEvent` → `AgentRunUpdateEvent`
- `MagenticAgentMessageEvent` → `ExecutorCompletedEvent`  
- `MagenticFinalResultEvent` → `WorkflowOutputEvent`

This PR upgrades to the new version and migrates our event handling.

## Changes

### Core Migration
- **`src/orchestrators/advanced.py`**: Updated imports and event handling loop
  - `AgentRunUpdateEvent.data.text` for streaming content
  - `ExecutorCompletedEvent.executor_id` for completion signals
  - `MAGENTIC_EVENT_TYPE_ORCHESTRATOR` constant for orchestrator messages

### Dependency Pinning
- **`pyproject.toml`**: Exact pin `==1.0.0b251204`
- **`requirements.txt`**: Exact pin `==1.0.0b251204`
- **`.pre-commit-config.yaml`**: Exact pin for mypy stubs

### Tests
- **`test_accumulator_pattern.py`**: Updated mock classes to new API
- **`test_advanced_events.py`**: Updated to use new event structure

### Documentation
- **`SPEC_18_AGENT_FRAMEWORK_UPGRADE.md`**: Full migration guide with API mapping

## Key Insight

The upstream release **FIXED the repr bug** we worked around in SPEC-17. Our Accumulator Pattern is kept as a safety net but may be removable in a future PR.

## Test Plan

- [x] All 302 unit tests pass
- [x] `make check` passes (lint + typecheck + tests)
- [x] Module import works: `from src.orchestrators.advanced import AdvancedOrchestrator`
- [ ] Manual smoke test on HuggingFace Spaces deployment

## References

- **Root cause**: Two P0 bugs from same pattern - beta dependencies with range pins drift on upstream releases
- **Lesson**: Beta packages need exact pins (`==1.0.0b251204` not `>=1.0.0b251120`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned agent-framework-core to exact pre-release version 1.0.0b251204.

* **Documentation**
  * Added SPEC-18 upgrade guide and updated workflow diagrams and document date.

* **Breaking Changes**
  * Public event names and their mappings were updated (streaming updates, completion, final output) — adjust integrations accordingly.

* **Tests**
  * Unit tests updated/mocked to reflect the new event shapes and processing semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->