### PR TITLE
fix(P2): Add LLM output sanitization to filter garbage tokens

### DIFF
--- a/docs/bugs/active-bugs.md
+++ b/docs/bugs/active-bugs.md
@@ -1,18 +1,30 @@
 # Active Bugs
 
-> Last updated: 2025-12-06
+> Last updated: 2025-12-08
 
 ---
 
-## P3 - Progress Bar Positioning in ChatInterface
+## ~~P2 - LLM Output Contamination (Free Tier)~~ (RESOLVED)
+
+**File:** [p2-llm-output-contamination.md](./p2-llm-output-contamination.md)
+**Status:** CLOSED (Implemented 2025-12-08)
+**Priority:** Medium (affects output quality)
+
+**Problem:** Qwen 2.5 7B occasionally outputs garbage tokens like `.ToDecimal` (C# method names) mid-output due to training data contamination.
+
+**Fix:** Added `src/utils/sanitize.py` with regex-based output filtering. Integrated into `src/orchestrators/advanced.py` at streaming emission point.
+
+---
+
+## ~~P3 - Progress Bar Positioning in ChatInterface~~ (RESOLVED)
 
 **File:** [p3-progress-bar-positioning.md](./p3-progress-bar-positioning.md)
-**Status:** OPEN
+**Status:** CLOSED (SPEC-22)
 **Priority:** Low (cosmetic UX issue)
 
 **Problem:** `gr.Progress()` conflicts with ChatInterface, causing the progress bar to float/overlap with chat messages.
 
-**Fix:** Remove `gr.Progress()` entirely and rely on emoji status messages in chat output.
+**Fix:** Removed `gr.Progress()` entirely per SPEC-22. Now uses `show_progress="full"` for native Gradio spinner.
 
 ---
 

--- a/docs/bugs/p2-llm-output-contamination.md
+++ b/docs/bugs/p2-llm-output-contamination.md
@@ -1,0 +1,203 @@
+# P2 Bug: LLM Output Contamination (`.ToDecimal` Hallucination)
+
+**Severity**: P2 (Medium - affects output quality)
+**Status**: IMPLEMENTED (2025-12-08)
+**Discovered**: 2025-12-07
+**Reporter**: User observation during live demo
+**Affected Tier**: Free Tier (HuggingFace / Qwen 2.5 7B)
+**Resolution**: Added `src/utils/sanitize.py` with regex-based output filtering
+
+## Symptom
+
+Random C# method-like tokens (`.ToDecimal`) appear in research output:
+
+```
+Focus on:
+- Identifying specific molecular targets
+- Understanding mechanism of action
+- Finding clinical evidence supporting hypotheses
+
+The final output should be a structured research report.
+
+.ToDecimal    <-- GARBAGE TOKEN
+Based on the search results from PubMed...
+```
+
+And again at the end of synthesis:
+```
+...ensure effective and safe treatment approaches.
+
+.ToDecimal /// can we deeply serach for any other bugs...    <-- GARBAGE FOLLOWED BY USER INPUT LEAK
+```
+
+## Root Cause Analysis
+
+### 1. LLM Hallucination
+
+`.ToDecimal` is a C# method (`Convert.ToDecimal()`). Qwen 2.5 7B was trained on code datasets that include C# - occasionally garbage tokens from training data leak into output.
+
+This is **NOT** a code bug - it's a model behavior issue.
+
+### 2. No Output Sanitization
+
+Currently, streaming output flows directly from LLM → UI with no filtering:
+
+```python
+# src/orchestrators/advanced.py:348-356
+text = getattr(event.data, "text", None)
+if text:
+    state.current_message_buffer += text
+    yield AgentEvent(
+        type="streaming",
+        message=text,  # Raw LLM output - no sanitization
+        data={"agent_id": author},
+        iteration=state.iteration,
+    )
+```
+
+### 3. Streaming Accumulation
+
+```python
+# src/app.py:195-201
+if event.type == "streaming":
+    streaming_buffer += event.message  # Accumulates raw tokens
+    current_parts = [*response_parts, f"📡 **STREAMING**: {streaming_buffer}"]
+    yield "\\n\\n".join(current_parts)
+```
+
+## Evidence
+
+| Pattern | Source | Frequency |
+|---------|--------|-----------|
+| `.ToDecimal` | C# `Convert.ToDecimal()` | Observed 2x in single session |
+| Potential others | `.ToString`, `.Parse`, etc. | Not yet observed |
+
+## Impact
+
+| Aspect | Impact |
+|--------|--------|
+| Functionality | None - research completes |
+| Output Quality | Unprofessional garbage in results |
+| User Trust | Reduces confidence in AI quality |
+| Reproducibility | Non-deterministic (temperature > 0) |
+
+## Affected Configuration
+
+- **Model**: `Qwen/Qwen2.5-7B-Instruct` (Free Tier)
+- **Provider**: HuggingFace Inference API
+- **Temperature**: 0.7 (default)
+- **Paid Tier (OpenAI)**: NOT observed - GPT-5 is more robust
+
+## Proposed Solutions
+
+### Option 1: Regex Filter for Known Garbage (RECOMMENDED)
+
+Add a sanitization layer for known hallucination patterns:
+
+```python
+import re
+
+# Known garbage patterns from smaller LLMs
+GARBAGE_PATTERNS = [
+    r'^\.[A-Z][a-zA-Z]+$',  # .ToDecimal, .ToString, .Parse
+    r'^<\|[a-z_]+\|>$',     # <|endoftext|>, <|im_end|>
+    r'^#{1,6}\s*$',          # Empty markdown headers
+]
+
+def sanitize_llm_output(text: str) -> str:
+    """Remove known LLM garbage tokens."""
+    lines = text.split('\\n')
+    cleaned = []
+    for line in lines:
+        stripped = line.strip()
+        is_garbage = any(re.match(p, stripped) for p in GARBAGE_PATTERNS)
+        if not is_garbage:
+            cleaned.append(line)
+    return '\\n'.join(cleaned)
+```
+
+**Pros**:
+- Simple, targeted fix
+- Low risk of false positives
+- Can expand pattern list as needed
+
+**Cons**:
+- Reactive (add patterns as discovered)
+- Doesn't fix root cause (model quality)
+
+### Option 2: Lower Temperature
+
+Reduce temperature from 0.7 to 0.3 for more deterministic output:
+
+```python
+# src/clients/huggingface.py
+temperature = chat_options.temperature if chat_options.temperature is not None else 0.3
+```
+
+**Pros**:
+- Reduces hallucination probability
+- Simple config change
+
+**Cons**:
+- Less creative/varied output
+- May affect research quality
+
+### Option 3: Use Larger Model (Long-term)
+
+Switch Free Tier to a larger, more robust model when available on HuggingFace native infrastructure.
+
+**Current Constraint**: Models > 30B get routed to unreliable third-party providers (see `CLAUDE.md`).
+
+### Option 4: Post-Processing Cleanup
+
+Add final cleanup step before yielding `complete` event:
+
+```python
+def _clean_final_output(self, content: str) -> str:
+    """Clean up LLM output before final display."""
+    # Remove isolated garbage tokens
+    content = re.sub(r'\\n\\s*\\.[A-Z][a-zA-Z]+\\s*\\n', '\\n', content)
+    return content.strip()
+```
+
+## Recommended Fix
+
+**Option 1 (Regex Filter)** - minimal risk, immediate improvement.
+
+Implement in `src/orchestrators/advanced.py` at the streaming event emission point.
+
+## Implementation Plan
+
+1. Add `src/utils/sanitize.py` with `sanitize_llm_output()` function
+2. Call sanitizer in `advanced.py` before yielding streaming events
+3. Add unit tests for known garbage patterns
+4. Monitor logs for new patterns to add
+
+## Testing
+
+```bash
+# Run research query and check output
+uv run python src/app.py
+
+# Submit: "What drugs improve female libido post-menopause?"
+# Verify: No .ToDecimal or similar garbage in output
+```
+
+## Related Issues
+
+- **Training Data Contamination**: Common in smaller LLMs trained on mixed datasets
+- **Token Boundary Issues**: Sometimes occurs at chunk boundaries during streaming
+- **Not a Bug in Our Code**: This is model behavior, not software defect
+
+## References
+
+- [Qwen 2.5 Model Card](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct)
+- [LLM Hallucination Patterns](https://arxiv.org/abs/2311.05232)
+- Similar issues in other projects using smaller LLMs
+
+## Version Info
+
+- DeepBoner: v0.1.0+
+- Gradio: 6.0.1
+- HuggingFace Client: huggingface_hub
+- Qwen Model: Qwen2.5-7B-Instruct

--- a/docs/bugs/p3-progress-bar-positioning.md
+++ b/docs/bugs/p3-progress-bar-positioning.md
@@ -1,9 +1,10 @@
 # P3 Bug: Progress Bar Positioning/Overlap in ChatInterface
 
 **Severity**: P3 (Low - UX polish)
-**Status**: Open
+**Status**: CLOSED (SPEC-22 implemented 2025-12-07)
 **Discovered**: 2025-12-01
 **Reporter**: Internal QA
+**Resolution**: Removed `gr.Progress()` entirely, added `show_progress="full"` to ChatInterface
 
 ## Symptom
 

--- a/src/utils/sanitize.py
+++ b/src/utils/sanitize.py
@@ -1,0 +1,132 @@
+"""LLM output sanitization utilities.
+
+This module provides defense-in-depth filtering for LLM outputs.
+Even premium models (GPT-4, Claude) can emit garbage tokens from training data.
+
+Principle: Never trust external systems. An LLM is an external system.
+
+References:
+- P2 Bug: docs/bugs/p2-llm-output-contamination.md
+- Observed artifacts: .ToDecimal (C# method), <|endoftext|> (training tokens)
+"""
+
+import re
+from typing import Final
+
+# Known garbage patterns from LLM training data contamination
+# Each pattern matches a COMPLETE line that should be removed
+_GARBAGE_LINE_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
+    # C#/Java method-like tokens: .ToDecimal, .ToString, .Parse, .GetType
+    re.compile(r"^\s*\.[A-Z][a-zA-Z]+\s*$"),
+    # Special tokens from various model architectures
+    re.compile(r"^\s*<\|[a-z_]+\|>\s*$"),  # <|endoftext|>, <|im_end|>
+    re.compile(r"^\s*<\|.*?\|>\s*$"),  # Broader special token catch
+    # Empty markdown headers (common formatting glitch)
+    re.compile(r"^\s*#{1,6}\s*$"),
+    # Isolated punctuation lines
+    re.compile(r"^\s*[.]{3,}\s*$"),  # Just ellipsis
+    re.compile(r"^\s*[-]{3,}\s*$"),  # Just dashes (but keep --- as separator)
+)
+
+# Inline patterns to remove (within a line, not the whole line)
+_GARBAGE_INLINE_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
+    # C# method calls appearing mid-text
+    re.compile(r"\s*\.[A-Z][a-zA-Z]+(?:\(\))?(?=\s|$)"),
+    # Stray special tokens inline
+    re.compile(r"<\|[a-z_]+\|>"),
+)
+
+
+def sanitize_streaming_text(text: str) -> str:
+    """Sanitize a single streaming chunk from LLM output.
+
+    This is called on each streaming token/chunk before yielding to UI.
+    Designed for low overhead on hot path.
+
+    Args:
+        text: Raw text chunk from LLM
+
+    Returns:
+        Sanitized text with garbage tokens removed
+
+    Example:
+        >>> sanitize_streaming_text(".ToDecimal")
+        ''
+        >>> sanitize_streaming_text("Normal medical text")
+        'Normal medical text'
+    """
+    if not text:
+        return text
+
+    # Fast path: most text is clean
+    # Check if any suspicious patterns might be present
+    # Note: '#' alone could be empty markdown header glitch
+    empty_headers = {"#", "##", "###", "####", "#####", "######"}
+    if "." not in text and "<|" not in text and text.strip() not in empty_headers:
+        return text
+
+    # Check full-line patterns (for single-line chunks)
+    stripped = text.strip()
+    for pattern in _GARBAGE_LINE_PATTERNS:
+        if pattern.match(stripped):
+            return ""
+
+    # Check inline patterns
+    result = text
+    for pattern in _GARBAGE_INLINE_PATTERNS:
+        result = pattern.sub("", result)
+
+    return result
+
+
+def sanitize_complete_output(text: str) -> str:
+    """Sanitize complete LLM output (multi-line).
+
+    Used for final output cleanup before displaying complete responses.
+
+    Args:
+        text: Complete multi-line text from LLM
+
+    Returns:
+        Sanitized text with garbage lines and tokens removed
+    """
+    if not text:
+        return text
+
+    lines = text.split("\n")
+    cleaned_lines: list[str] = []
+
+    for line in lines:
+        # Check if entire line is garbage
+        stripped = line.strip()
+        is_garbage_line = any(p.match(stripped) for p in _GARBAGE_LINE_PATTERNS)
+
+        if is_garbage_line:
+            continue  # Skip this line entirely
+
+        # Clean inline garbage from the line
+        cleaned = line
+        for pattern in _GARBAGE_INLINE_PATTERNS:
+            cleaned = pattern.sub("", cleaned)
+
+        cleaned_lines.append(cleaned)
+
+    return "\n".join(cleaned_lines)
+
+
+def is_garbage_token(text: str) -> bool:
+    """Check if text is purely a garbage token.
+
+    Useful for pre-filtering before accumulation.
+
+    Args:
+        text: Text to check
+
+    Returns:
+        True if text matches known garbage patterns
+    """
+    if not text:
+        return False
+
+    stripped = text.strip()
+    return any(p.match(stripped) for p in _GARBAGE_LINE_PATTERNS)

--- a/tests/unit/utils/test_sanitize.py
+++ b/tests/unit/utils/test_sanitize.py
@@ -1,0 +1,201 @@
+"""Unit tests for LLM output sanitization.
+
+Tests verify that known garbage patterns are filtered while
+legitimate medical/research text passes through unchanged.
+
+Reference: docs/bugs/p2-llm-output-contamination.md
+"""
+
+import pytest
+
+from src.utils.sanitize import (
+    is_garbage_token,
+    sanitize_complete_output,
+    sanitize_streaming_text,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestSanitizeStreamingText:
+    """Tests for streaming chunk sanitization."""
+
+    def test_removes_todecimal_token(self):
+        """Should remove .ToDecimal (the original reported bug)."""
+        assert sanitize_streaming_text(".ToDecimal") == ""
+
+    def test_removes_tostring_token(self):
+        """Should remove other C# method-like tokens."""
+        assert sanitize_streaming_text(".ToString") == ""
+        assert sanitize_streaming_text(".Parse") == ""
+        assert sanitize_streaming_text(".GetType") == ""
+
+    def test_removes_special_tokens(self):
+        """Should remove LLM special tokens."""
+        assert sanitize_streaming_text("<|endoftext|>") == ""
+        assert sanitize_streaming_text("<|im_end|>") == ""
+        assert sanitize_streaming_text("<|im_start|>") == ""
+
+    def test_preserves_normal_text(self):
+        """Should pass through normal medical text unchanged."""
+        text = "Testosterone therapy shows efficacy in treating HSDD."
+        assert sanitize_streaming_text(text) == text
+
+    def test_preserves_text_with_periods(self):
+        """Should not remove periods in normal sentences."""
+        text = "Dr. Smith conducted the study. Results were positive."
+        assert sanitize_streaming_text(text) == text
+
+    def test_preserves_abbreviations(self):
+        """Should preserve medical abbreviations."""
+        text = "The FDA approved the drug. HSDD affects many patients."
+        assert sanitize_streaming_text(text) == text
+
+    def test_preserves_markdown_headers(self):
+        """Should preserve markdown headers with content."""
+        text = "## Executive Summary"
+        assert sanitize_streaming_text(text) == text
+
+    def test_removes_empty_markdown_headers(self):
+        """Should remove empty markdown headers (formatting glitch)."""
+        assert sanitize_streaming_text("###") == ""
+        assert sanitize_streaming_text("## ") == ""
+
+    def test_handles_empty_string(self):
+        """Should handle empty input gracefully."""
+        assert sanitize_streaming_text("") == ""
+
+    def test_handles_whitespace_only(self):
+        """Should handle whitespace input."""
+        assert sanitize_streaming_text("   ") == "   "
+
+    def test_removes_inline_garbage(self):
+        """Should remove garbage tokens appearing mid-text."""
+        text = "Normal text .ToDecimal more text"
+        result = sanitize_streaming_text(text)
+        assert ".ToDecimal" not in result
+        assert "Normal text" in result
+
+    def test_fast_path_no_suspicious_chars(self):
+        """Should use fast path when no suspicious patterns possible."""
+        # Text without '.' or '<|' should return immediately
+        text = "Simple text without suspicious characters"
+        assert sanitize_streaming_text(text) == text
+
+
+class TestSanitizeCompleteOutput:
+    """Tests for complete multi-line output sanitization."""
+
+    def test_removes_garbage_lines(self):
+        """Should remove entire lines that are garbage."""
+        text = "Line one.\n.ToDecimal\nLine three."
+        result = sanitize_complete_output(text)
+        assert ".ToDecimal" not in result
+        assert "Line one." in result
+        assert "Line three." in result
+
+    def test_preserves_structure(self):
+        """Should preserve document structure."""
+        text = """## Summary
+This is the summary.
+
+## Methods
+These are the methods."""
+        result = sanitize_complete_output(text)
+        assert "## Summary" in result
+        assert "## Methods" in result
+
+    def test_handles_multiple_garbage_tokens(self):
+        """Should remove multiple different garbage tokens."""
+        text = "Good text.\n.ToDecimal\n<|endoftext|>\nMore good text."
+        result = sanitize_complete_output(text)
+        assert ".ToDecimal" not in result
+        assert "<|endoftext|>" not in result
+        assert "Good text." in result
+        assert "More good text." in result
+
+    def test_handles_empty_input(self):
+        """Should handle empty input."""
+        assert sanitize_complete_output("") == ""
+
+    def test_cleans_inline_garbage_in_lines(self):
+        """Should clean inline garbage while preserving surrounding text."""
+        text = "Start .ToString end"
+        result = sanitize_complete_output(text)
+        assert ".ToString" not in result
+        assert "Start" in result
+        assert "end" in result
+
+
+class TestIsGarbageToken:
+    """Tests for garbage detection helper."""
+
+    def test_detects_csharp_methods(self):
+        """Should detect C# method-like tokens."""
+        assert is_garbage_token(".ToDecimal") is True
+        assert is_garbage_token(".ToString") is True
+        assert is_garbage_token("  .Parse  ") is True
+
+    def test_detects_special_tokens(self):
+        """Should detect LLM special tokens."""
+        assert is_garbage_token("<|endoftext|>") is True
+        assert is_garbage_token("<|im_end|>") is True
+
+    def test_rejects_normal_text(self):
+        """Should not flag normal text as garbage."""
+        assert is_garbage_token("Normal text") is False
+        assert is_garbage_token("Dr. Smith") is False
+        assert is_garbage_token("## Header") is False
+
+    def test_handles_empty(self):
+        """Should handle empty input."""
+        assert is_garbage_token("") is False
+        assert is_garbage_token(None) is False  # type: ignore[arg-type]
+
+
+class TestIntegrationWithOrchestrator:
+    """Tests verifying integration with orchestrator flow."""
+
+    def test_streaming_filter_scenario(self):
+        """Simulate the actual bug scenario from production."""
+        # This simulates what was observed:
+        # LLM outputs ".ToDecimal" between normal text chunks
+        chunks = [
+            "Research sexual health",
+            " and wellness interventions",
+            ".ToDecimal",
+            " for testosterone therapy.",
+        ]
+
+        accumulated = ""
+        for chunk in chunks:
+            clean = sanitize_streaming_text(chunk)
+            if clean:
+                accumulated += clean
+
+        assert ".ToDecimal" not in accumulated
+        assert "Research sexual health" in accumulated
+        assert "wellness interventions" in accumulated
+        assert "testosterone therapy" in accumulated
+
+    def test_preserves_medical_terminology(self):
+        """Should not corrupt medical terms with periods."""
+        medical_terms = [
+            "P.O. administration",
+            "q.d. dosing",
+            "i.v. injection",
+            "E. coli infection",
+            "S. aureus colonization",
+        ]
+        for term in medical_terms:
+            assert sanitize_streaming_text(term) == term
+
+    def test_preserves_citations(self):
+        """Should not corrupt citation formats."""
+        citations = [
+            "(Smith et al., 2024)",
+            "[1] PubMed: 12345678",
+            "DOI: 10.1234/example.2024",
+        ]
+        for citation in citations:
+            assert sanitize_streaming_text(citation) == citation


### PR DESCRIPTION
## Summary

- Implements defense-in-depth filtering for LLM outputs that occasionally contain training data contamination
- Observed bug: `.ToDecimal` (C# method) appearing mid-output from Qwen 2.5 7B
- Fix applies to ALL LLM backends, not just small models (principle: never trust external systems)

## Changes

| File | Purpose |
|------|---------|
| `src/utils/sanitize.py` | **NEW** - Regex-based output filtering module |
| `src/orchestrators/advanced.py` | Integrated sanitizer at streaming emission point |
| `tests/unit/utils/test_sanitize.py` | **NEW** - 24 comprehensive unit tests |
| `docs/bugs/p2-llm-output-contamination.md` | **NEW** - Bug documentation |
| `docs/bugs/active-bugs.md` | Updated index (P2 RESOLVED, P3 RESOLVED) |

## What Gets Filtered

| Pattern | Example | Source |
|---------|---------|--------|
| C# methods | `.ToDecimal`, `.ToString` | Training data contamination |
| Special tokens | `<\|endoftext\|>` | Model architecture artifacts |
| Empty headers | `###` | Formatting glitches |

## What Passes Through (Verified by Tests)

- Medical terms: `Dr. Smith`, `P.O. administration`, `E. coli`
- Citations: `(Smith et al., 2024)`, `DOI: 10.1234/...`
- Markdown headers with content: `## Executive Summary`

## Test plan

- [x] 24 unit tests pass
- [x] Lint passes (ruff)
- [x] Type check passes (mypy)
- [x] External audit verified implementation correctness
- [ ] Manual test on HuggingFace Spaces after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved LLM output contamination where certain models occasionally emit corrupted tokens mid-response; garbage tokens are now automatically filtered.
  * Fixed progress bar display positioning in the chat interface.

* **Tests**
  * Added unit tests for output sanitization and garbage-token detection validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->